### PR TITLE
Remove email address from the UserSummaryDTO

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -22,7 +22,7 @@ import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
 
 /**
  * EventBookingPersistenceManager.
@@ -226,7 +226,7 @@ public class EventBookingPersistenceManager {
         EventBookingDTO result = new EventBookingDTO();
 
         try {
-            UserSummaryDTO user = userManager.convertToUserSummaryObject(userManager.getUserDTOById(eb
+            DetailedUserSummaryDTO user = userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(eb
                     .getUserId()));
 
             result.setBookingId(eb.getId());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
@@ -262,7 +262,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
             RegisteredUserDTO userDTO = userManager.getUserDTOById(associationManager.lookupTokenDetails(
                     currentRegisteredUser, token).getOwnerUserId());
 
-            return Response.ok(userManager.convertToTeacherUserSummaryObject(userDTO))
+            return Response.ok(userManager.convertToDetailedUserSummaryObject(userDTO))
                     .cacheControl(getCacheControl(Constants.NUMBER_SECONDS_IN_FIVE_MINUTES, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
@@ -262,7 +262,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
             RegisteredUserDTO userDTO = userManager.getUserDTOById(associationManager.lookupTokenDetails(
                     currentRegisteredUser, token).getOwnerUserId());
 
-            return Response.ok(userManager.convertToUserSummaryObject(userDTO))
+            return Response.ok(userManager.convertToTeacherUserSummaryObject(userDTO))
                     .cacheControl(getCacheControl(Constants.NUMBER_SECONDS_IN_FIVE_MINUTES, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -67,6 +67,7 @@ import uk.ac.cam.cl.dtg.segue.dto.users.AbstractSegueUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.TeacherUserSummaryDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import com.google.api.client.util.Lists;
@@ -1078,6 +1079,17 @@ public class UserAccountManager {
      */
     public UserSummaryDTO convertToUserSummaryObject(final RegisteredUserDTO userToConvert) {
         return this.dtoMapper.map(userToConvert, UserSummaryDTO.class);
+    }
+
+    /**
+     * Helper method to convert a user object into a cutdown teacherUserSummary DTO.
+     *
+     * @param userToConvert
+     *            - full user object.
+     * @return a summarised object with reduced personal information
+     */
+    public TeacherUserSummaryDTO convertToTeacherUserSummaryObject(final RegisteredUserDTO userToConvert) {
+        return this.dtoMapper.map(userToConvert, TeacherUserSummaryDTO.class);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -67,7 +67,7 @@ import uk.ac.cam.cl.dtg.segue.dto.users.AbstractSegueUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.TeacherUserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import com.google.api.client.util.Lists;
@@ -1088,8 +1088,8 @@ public class UserAccountManager {
      *            - full user object.
      * @return a summarised object with reduced personal information
      */
-    public TeacherUserSummaryDTO convertToTeacherUserSummaryObject(final RegisteredUserDTO userToConvert) {
-        return this.dtoMapper.map(userToConvert, TeacherUserSummaryDTO.class);
+    public DetailedUserSummaryDTO convertToDetailedUserSummaryObject(final RegisteredUserDTO userToConvert) {
+        return this.dtoMapper.map(userToConvert, DetailedUserSummaryDTO.class);
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAssociationManager.java
@@ -278,7 +278,6 @@ public class UserAssociationManager {
             userRequested.setAuthorisedFullAccess(true);
         } else {
             userRequested.setAuthorisedFullAccess(false);
-            userRequested.setEmail(null);
         }
         return userRequested;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/DetailedUserSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/DetailedUserSummaryDTO.java
@@ -18,13 +18,13 @@ package uk.ac.cam.cl.dtg.segue.dto.users;
 /**
  * Teacher User Summary object, which contains additional information (email).
  */
-public class TeacherUserSummaryDTO extends UserSummaryDTO {
+public class DetailedUserSummaryDTO extends UserSummaryDTO {
     private String email;
 
     /**
      * UserSummaryDTO.
      */
-    public TeacherUserSummaryDTO() {
+    public DetailedUserSummaryDTO() {
 
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/TeacherUserSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/TeacherUserSummaryDTO.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.dto.users;
+
+/**
+ * Teacher User Summary object, which contains additional information (email).
+ */
+public class TeacherUserSummaryDTO extends UserSummaryDTO {
+    private String email;
+
+    /**
+     * UserSummaryDTO.
+     */
+    public TeacherUserSummaryDTO() {
+
+    }
+
+    /**
+     * Gets the email.
+     * @return the email
+     */
+    public String getEmail() {
+        return email;
+    }
+
+
+    /**
+     * Sets the email.
+     * @param email the id to set
+     */
+    public void setEmail(final String email) {
+        this.email = email;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("UserSummaryDTO [databaseId=");
+        builder.append(this.getLegacyDbId());
+        builder.append(", givenName=");
+        builder.append(this.getGivenName());
+        builder.append(", familyName=");
+        builder.append(this.getFamilyName());
+        builder.append(", email=");
+        builder.append(email);
+        builder.append(", authorisedFullAccess=");
+        builder.append(this.isAuthorisedFullAccess());
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryDTO.java
@@ -26,7 +26,6 @@ public class UserSummaryDTO extends AbstractSegueUserDTO {
     private Long id;
     private String givenName;
     private String familyName;
-    private String email;
     private Role role;
     private boolean authorisedFullAccess;
 
@@ -115,25 +114,6 @@ public class UserSummaryDTO extends AbstractSegueUserDTO {
     }
 
     /**
-     * Gets the email.
-     * 
-     * @return the email
-     */
-    public String getEmail() {
-        return email;
-    }
-
-    /**
-     * Sets the email.
-     * 
-     * @param email
-     *            the email to set
-     */
-    public void setEmail(final String email) {
-        this.email = email;
-    }
-
-    /**
      * Gets the role.
      *
      * @return the role
@@ -180,8 +160,6 @@ public class UserSummaryDTO extends AbstractSegueUserDTO {
         builder.append(givenName);
         builder.append(", familyName=");
         builder.append(familyName);
-        builder.append(", email=");
-        builder.append(email);
         builder.append(", authorisedFullAccess=");
         builder.append(authorisedFullAccess);
         builder.append("]");


### PR DESCRIPTION
This increases user email privacy from 'hidden, but still disclosed' to 'not disclosed unless necessary'. The token owner lookup still needs emails, to allow students to verify their teacher's identity; this still allows this.

The change may cause issues on the event booking page (in [`admin_events.html`](https://github.com/ucam-cl-dtg/isaac-app/blob/master/app/partials/states/admin_events.html#L91)) but I'm not sure the email should really be there anyway. We should just add support for emailing all users booked on and event through the email code we have . . .