### PR TITLE
Stop the log_events table from storing null valued fields in its event_details JSON.

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -85,6 +85,7 @@ import uk.ac.cam.cl.dtg.util.locations.PostCodeIOLocationResolver;
 import uk.ac.cam.cl.dtg.util.locations.PostCodeLocationResolver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.api.client.util.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
@@ -353,7 +354,9 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
         if (null == logManager) {
             //logManager = new MongoLogManager(database, new ObjectMapper(), loggingEnabled, lhm);
             
-            logManager = new PgLogManager(database, new ObjectMapper(), loggingEnabled, lhm);
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            logManager = new PgLogManager(database, objectMapper, loggingEnabled, lhm);
             
             log.info("Creating singleton of LogManager");
             if (loggingEnabled) {


### PR DESCRIPTION
Issue https://github.com/ucam-cl-dtg/isaac-app/issues/790.

This would stop the log_events table from storing null valued fields in event_details **for every event_type, not just 'Answer Question'**.
From skimming through non-'Answer Question' log events, it seems like the other event_types which store null values are QUESTION_ATTEMPT_RATE_LIMITED and USER_SCHOOL_CHANGE.

The only event_type which seems to me that might want to usefully store null values is the EQN_EDITOR_LOG @Morpheu5. It does not seem to do so, so I think this change is fine.