### PR TITLE
Feature/return question part status information

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -442,7 +442,7 @@ public class GameManager {
         
         double boardPercentage = 0;
         for (Float questionPercentage : questionPercentages) {
-            boardPercentage += questionPercentage / questionPercentages.size();
+            boardPercentage += (double) questionPercentage / (double) questionPercentages.size();
         }
         gameboardDTO.setPercentageCompleted((int) Math.round(boardPercentage));
         

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -412,7 +412,6 @@ public class GameManager {
      *            - the users question data.
      * @param user
      *            - the users data.
-     * @return Augmented Gameboard
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      * @throws SegueDatabaseException if we can't look up gameboard --> user information
@@ -429,8 +428,9 @@ public class GameManager {
         for (GameboardItem gameItem : gameboardDTO.getQuestions()) {
             try {
                 this.augmentGameItemWithAttemptInformation(gameItem, questionAttemptsFromUser);
-                questionPercentages.add(gameItem.calculatePercentageOfQuestionParts(gameItem.getQuestionPartsCorrect()));
-                if (!gameItem.getState().equals(GameboardItemState.NOT_ATTEMPTED) && !gameboardDTO.isStartedQuestion()) {
+                questionPercentages.add(gameItem.calculateQuestionPartPercentage(gameItem.getQuestionPartsCorrect()));
+                if (!gameItem.getState().equals(GameboardItemState.NOT_ATTEMPTED)
+                        && !gameboardDTO.isStartedQuestion()) {
                     gameboardDTO.setStartedQuestion(true);
                 }
             } catch (ResourceNotFoundException e) {
@@ -931,7 +931,6 @@ public class GameManager {
      *            - the gameboard item.
      * @param questionAttemptsFromUser
      *            - the user that may or may not have attempted questions in the gameboard.
-     * @return The state of the gameboard item.
      * @throws ContentManagerException
      *             - if there is an error retrieving the content requested.
      * @throws ResourceNotFoundException
@@ -958,7 +957,8 @@ public class GameManager {
                     // there is a correct answer somewhere.
                     boolean foundCorrectForThisQuestion = false;
                     for (int i = questionPartAttempts.size() - 1; i >= 0; i--) {
-                        if (questionPartAttempts.get(i).isCorrect() != null && questionPartAttempts.get(i).isCorrect()) {
+                        if (questionPartAttempts.get(i).isCorrect() != null
+                                && questionPartAttempts.get(i).isCorrect()) {
                             foundCorrectForThisQuestion = true;
                             break;
                         }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -936,7 +936,7 @@ public class GameManager {
      *             - if there is an error retrieving the content requested.
      * @throws ResourceNotFoundException
      *             - if we cannot find the question specified.
-     */ //., TODO MT update
+     */
     private void augmentGameItemWithAttemptInformation(final GameboardItem gameItem,
             final Map<String, Map<String, List<QuestionValidationResponse>>> questionAttemptsFromUser)
             throws ContentManagerException, ResourceNotFoundException {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -178,7 +178,8 @@ public class GameManager {
 
             this.gameboardPersistenceManager.temporarilyStoreGameboard(gameboardDTO);
 
-            return augmentGameboardWithUserInformation(gameboardDTO, usersQuestionAttempts, boardOwner);
+            this.augmentGameboardWithUserInformation(gameboardDTO, usersQuestionAttempts, boardOwner);
+            return gameboardDTO;
         } else {
             return null;
         }
@@ -280,9 +281,8 @@ public class GameManager {
             final Map<String, Map<String, List<QuestionValidationResponse>>> userQuestionAttempts)
             throws SegueDatabaseException, ContentManagerException {
 
-        GameboardDTO gameboardFound = augmentGameboardWithUserInformation(
-                this.gameboardPersistenceManager.getGameboardById(gameboardId), userQuestionAttempts, user);
-
+        GameboardDTO gameboardFound = this.gameboardPersistenceManager.getGameboardById(gameboardId);
+        this.augmentGameboardWithUserInformation(gameboardFound, userQuestionAttempts, user);
         return gameboardFound;
     }
 
@@ -417,44 +417,36 @@ public class GameManager {
      *             - if there is an error retrieving the content requested.
      * @throws SegueDatabaseException if we can't look up gameboard --> user information
      */
-    public final GameboardDTO augmentGameboardWithUserInformation(final GameboardDTO gameboardDTO,
+    public final void augmentGameboardWithUserInformation(final GameboardDTO gameboardDTO,
             final Map<String, Map<String, List<QuestionValidationResponse>>> questionAttemptsFromUser, 
             final AbstractSegueUserDTO user)
             throws ContentManagerException, SegueDatabaseException {
-        if (null == gameboardDTO) {
-            return null;
-        }
-
-        if (null == questionAttemptsFromUser || gameboardDTO.getQuestions().size() == 0) {
-            return gameboardDTO;
+        if (null == gameboardDTO || null == questionAttemptsFromUser || gameboardDTO.getQuestions().size() == 0) {
+            return;
         }
 
         int totalCompleted = 0;
         int totalUnavailable = 0;
         
         for (GameboardItem gameItem : gameboardDTO.getQuestions()) {
-            GameboardItemState state;
             try {
-                state = this.calculateQuestionState(gameItem.getId(), questionAttemptsFromUser);    
+                this.augmentGameItemWithAttemptInformation(gameItem, questionAttemptsFromUser);
+                GameboardItemState state = gameItem.getState();
+                if (state.equals(GameboardItemState.PASSED) || state.equals(GameboardItemState.PERFECT)) {
+                    totalCompleted++;
+                }
+                if (!state.equals(GameboardItemState.NOT_ATTEMPTED) && !gameboardDTO.isStartedQuestion()) {
+                    gameboardDTO.setStartedQuestion(true);
+                }
             } catch (ResourceNotFoundException e) {
                 log.info(String.format(
                         "A question is unavailable (%s) - treating it as if it never existed for marking.",
                         gameItem.getId()));
                 totalUnavailable++;
-                continue;
-            }
-            
-            gameItem.setState(state);
-            
-            if (state.equals(GameboardItemState.PASSED) || state.equals(GameboardItemState.PERFECT)) {
-                totalCompleted++;
-            }
-
-            if (!state.equals(GameboardItemState.NOT_ATTEMPTED) && !gameboardDTO.isStartedQuestion()) {
-                gameboardDTO.setStartedQuestion(true);
             }
         }
         
+        //., TODO MT - set this to calculate a better percentage which takes question parts into consideration
         int totalQuestionInBoard = gameboardDTO.getQuestions().size() - totalUnavailable;
         
         double percentageCompleted = totalCompleted * 100 / totalQuestionInBoard;
@@ -464,8 +456,6 @@ public class GameManager {
             gameboardDTO
                     .setSavedToCurrentUser(this.isBoardLinkedToUser((RegisteredUserDTO) user, gameboardDTO.getId()));
         }
-        
-        return gameboardDTO;
     }
 
     /**
@@ -586,9 +576,10 @@ public class GameManager {
         for (RegisteredUserDTO user : users) {
             List<GameboardItemState> listOfQuestionStates = Lists.newArrayList();
 
-            for (GameboardItem question : gameboard.getQuestions()) {
-                listOfQuestionStates.add(this.calculateQuestionState(question.getId(),
-                        questionAttemptsForAllUsersOfInterest.get(user.getId())));
+            for (GameboardItem gameItem : gameboard.getQuestions()) {
+                this.augmentGameItemWithAttemptInformation(gameItem,
+                    questionAttemptsForAllUsersOfInterest.get(user.getId()));
+                listOfQuestionStates.add(gameItem.getState());
             }
             result.put(user, listOfQuestionStates);
         }
@@ -839,14 +830,14 @@ public class GameManager {
 
                 GameboardItemState questionState;
                 try {
-                    questionState = this.calculateQuestionState(gameboardItem.getId(),
-                            usersQuestionAttempts);
+                    this.augmentGameItemWithAttemptInformation(gameboardItem, usersQuestionAttempts);
                 } catch (ResourceNotFoundException e) {
                     throw new ContentManagerException(
                             "Resource not found exception, this shouldn't happen as the selectionOfGameboardQuestions "
                             + "should only show available content.");
                 }
                 
+                questionState = gameboardItem.getState();
                 if (questionState.equals(GameboardItemState.PASSED) 
                         || questionState.equals(GameboardItemState.PERFECT)) {
                     completedQuestions.add(gameboardItem);
@@ -942,8 +933,8 @@ public class GameManager {
      * 
      * This method will calculate the question state for use in gameboards based on the question.
      * 
-     * @param questionPageId
-     *            - the gameboard item id.
+     * @param gameItem
+     *            - the gameboard item.
      * @param questionAttemptsFromUser
      *            - the user that may or may not have attempted questions in the gameboard.
      * @return The state of the gameboard item.
@@ -951,89 +942,55 @@ public class GameManager {
      *             - if there is an error retrieving the content requested.
      * @throws ResourceNotFoundException
      *             - if we cannot find the question specified.
-     */
-    private GameboardItemState calculateQuestionState(final String questionPageId,
+     */ //., TODO MT update
+    private void augmentGameItemWithAttemptInformation(final GameboardItem gameItem,
             final Map<String, Map<String, List<QuestionValidationResponse>>> questionAttemptsFromUser)
             throws ContentManagerException, ResourceNotFoundException {
-        Validate.notBlank(questionPageId, "QuestionPageId cannot be empty or blank");
-        Validate.notNull(questionAttemptsFromUser, "questionAttemptsFromUser cannot null");
+        Validate.notNull(gameItem, "gameItem cannot be null");
+        Validate.notNull(questionAttemptsFromUser, "questionAttemptsFromUser cannot be null");
 
-        if (questionAttemptsFromUser.containsKey(questionPageId)) {
-            // get all questions in the question page: depends on each question
-            // having an id that starts with the question page id.
+        int questionPartsCorrect = 0, questionPartsIncorrect = 0, questionPartsNotAttempted = 0;
+        String questionPageId = gameItem.getId();
 
-            // Get the pass mark for the question page
-            IsaacQuestionPage questionPage = (IsaacQuestionPage) this.contentManager.getContentDOById(
-                    this.contentManager.getCurrentContentSHA(), questionPageId);
-            
-            if (null == questionPage) {
-                throw new ResourceNotFoundException(String.format("Unable to locate the question: %s for augmenting",
-                        questionPageId));
-            }
-            
-            Float passMark = questionPage.getPassMark();
-            if (passMark == null) {
-                passMark = 100f;
-            }
-
-            // go through each question in the question page
-            Collection<QuestionDTO> listOfQuestions = getAllMarkableQuestionParts(questionPageId);
-
-            // go through all of the questions that make up this gameboard item.
-            int questionPartsCorrect = 0;
-            int questionPartsIncorrect = 0;
-            int questionPartsNotAttempted = 0;
-            for (ContentDTO contentDTO : listOfQuestions) {
-                // get the attempts for this particular question.
-                List<QuestionValidationResponse> questionAttempts = questionAttemptsFromUser.get(questionPageId).get(
-                        contentDTO.getId());
-
-                // If we have an entry for the question page and do not have
-                // any attempts for this question then it means that we have
-                // done something on this question but have not yet answered
-                // all parts.
-                if (questionAttemptsFromUser.get(questionPageId) != null && null == questionAttempts) {
-                    questionPartsNotAttempted++;
-                    continue;
-                }
-
-                boolean foundCorrectForThisQuestion = false;
-
-                // Go through the attempts in reverse chronological order
-                // for this question to determine if there is a
-                // correct answer somewhere.
-                for (int i = questionAttempts.size() - 1; i >= 0; i--) {
-                    if (questionAttempts.get(i).isCorrect() != null && questionAttempts.get(i).isCorrect()) {
-                        foundCorrectForThisQuestion = true;
-                        break;
+        // get all question parts in the question page: depends on each question
+        // having an id that starts with the question page id.
+        Collection<QuestionDTO> listOfQuestionParts = getAllMarkableQuestionParts(questionPageId);
+        Map<String, List<QuestionValidationResponse>> questionAttempts = questionAttemptsFromUser.get(questionPageId);
+        if (questionAttempts != null) {
+            for (ContentDTO questionPart : listOfQuestionParts) {
+                List<QuestionValidationResponse> questionPartAttempts = questionAttempts.get(questionPart.getId());
+                if (questionPartAttempts != null) {
+                    // Go through the attempts in reverse chronological order for this question part to determine if
+                    // there is a correct answer somewhere.
+                    boolean foundCorrectForThisQuestion = false;
+                    for (int i = questionPartAttempts.size() - 1; i >= 0; i--) {
+                        if (questionPartAttempts.get(i).isCorrect() != null && questionPartAttempts.get(i).isCorrect()) {
+                            foundCorrectForThisQuestion = true;
+                            break;
+                        }
                     }
-                }
-
-                if (foundCorrectForThisQuestion) {
-                    questionPartsCorrect++;
+                    if (foundCorrectForThisQuestion) {
+                        questionPartsCorrect++;
+                    } else {
+                        questionPartsIncorrect++;
+                    }
                 } else {
-                    questionPartsIncorrect++;
+                    questionPartsNotAttempted++;
                 }
             }
-
-            int totalParts = questionPartsCorrect + questionPartsIncorrect + questionPartsNotAttempted;
-
-            float percentCorrect = 100 * (float) questionPartsCorrect / totalParts;
-            float percentIncorrect = 100 * (float) questionPartsIncorrect / totalParts;
-
-            if (questionPartsCorrect == totalParts) {
-                return GameboardItemState.PERFECT;
-            } else if (percentCorrect >= passMark) {
-                return GameboardItemState.PASSED;
-            } else if (percentIncorrect > (100 - passMark)) {
-                return GameboardItemState.FAILED;
-            } else {
-                return GameboardItemState.IN_PROGRESS;
-            }
-
         } else {
-            return GameboardItemState.NOT_ATTEMPTED;
+            questionPartsNotAttempted = listOfQuestionParts.size();
         }
+
+        // Get the pass mark for the question page
+        IsaacQuestionPage questionPage = (IsaacQuestionPage) this.contentManager.getContentDOById(
+                this.contentManager.getCurrentContentSHA(), questionPageId);
+        if (questionPage == null) {
+            throw new ResourceNotFoundException(String.format("Unable to locate the question: %s for augmenting",
+                    questionPageId));
+        }
+        gameItem.setStatusInformation(
+                questionPartsCorrect, questionPartsIncorrect, questionPartsNotAttempted, questionPage.getPassMark());
     }
     
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -438,7 +438,7 @@ public class GameboardPersistenceManager {
 		
 		return errors;
 	}
-	
+
 	/**
 	 * Attempt to improve performance of getting gameboard items in a batch.
 	 * 
@@ -457,8 +457,8 @@ public class GameboardPersistenceManager {
 			questionIds.addAll(ids);
 			gameboardToQuestionsMap.put(game.getId(), ids);
 		}
-		
-		if (!questionIds.isEmpty()) {
+
+        if (!questionIds.isEmpty()) {
             Map<String, GameboardItem> gameboardReadyQuestions = getGameboardItemMap(Lists.newArrayList(questionIds));
             for (GameboardDTO game : gameboards) {
                 ArrayList<GameboardItem> newItems = new ArrayList<GameboardItem>(); 
@@ -477,10 +477,10 @@ public class GameboardPersistenceManager {
                 game.setQuestions(newItems);
             }
         } else {
-			log.info("No question ids found; returning without augmenting.");
-		}
-	}
-	
+            log.info("No question ids found; returning without augmenting.");
+        }
+    }
+
     /**
      * Utility method to get a map of gameboard id to list of users who are connected to it.
      * 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -448,39 +448,38 @@ public class GameboardPersistenceManager {
 	 * @param gameboards - list of gameboards to fully augment.
 	 * @return augmented gameboards as per inputted list.
 	 */
-	public List<GameboardDTO> augmentGameboardItems(final List<GameboardDTO> gameboards) {
-		Set<String> qids = Sets.newHashSet();
+	public void augmentGameboardItems(final List<GameboardDTO> gameboards) {
+		Set<String> questionIds = Sets.newHashSet();
 		Map<String, List<String>> gameboardToQuestionsMap = Maps.newHashMap();
 
 		// go through all game boards working out the set of question ids.
 		for (GameboardDTO game : gameboards) {
 			List<String> ids = getQuestionIds(game);
-			qids.addAll(ids);
+			questionIds.addAll(ids);
 			gameboardToQuestionsMap.put(game.getId(), ids);
 		}
 		
-		if (qids.isEmpty()) {
-			log.info("No question ids found; returning original gameboard without augmenting.");
-			return gameboards;
-		}
-		
-		Map<String, GameboardItem> gameboardReadyQuestions = getGameboardItemMap(Lists.newArrayList(qids));
-		for (GameboardDTO game : gameboards) {
-			// empty and re-populate the gameboard dto with fully augmented gameboard items.
-			game.setQuestions(new ArrayList<GameboardItem>());
-			for (String questionid : gameboardToQuestionsMap.get(game.getId())) {
-				// There is a possibility that the question cannot be found any more for some reason
-				// In this case we will simply pretend it isn't there.
-				GameboardItem item = gameboardReadyQuestions.get(questionid);
-				if (item != null) {
-					game.getQuestions().add(item);	
-                } else {
-                    log.warn("The gameboard: " + game.getId() + " has a reference to a question (" + questionid
-                            + ") that we cannot find. Removing it from the DTO.");
+		if (!questionIds.isEmpty()) {
+            Map<String, GameboardItem> gameboardReadyQuestions = getGameboardItemMap(Lists.newArrayList(questionIds));
+            for (GameboardDTO game : gameboards) {
+                ArrayList<GameboardItem> newItems = new ArrayList<GameboardItem>(); 
+                for (GameboardItem oldItem : game.getQuestions()) {
+                    GameboardItem newItem = gameboardReadyQuestions.get(oldItem.getId());
+                    if (newItem != null) {
+                        newItem.setStatusInformation(
+                                oldItem.getQuestionPartsCorrect(), oldItem.getQuestionPartsIncorrect(),
+                                oldItem.getQuestionPartsNotAttempted(), oldItem.getPassMark());
+                        newItems.add(newItem);
+                    } else {
+                        log.warn("The gameboard: " + game.getId() + " has a reference to a question (" + oldItem.getId()
+                                + ") that we cannot find. Removing it from the DTO.");
+                    }
                 }
-			}
-		}	
-		return gameboards;
+                game.setQuestions(newItems);
+            }
+        } else {
+			log.info("No question ids found; returning without augmenting.");
+		}
 	}
 	
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/GameboardPersistenceManager.java
@@ -446,7 +446,6 @@ public class GameboardPersistenceManager {
 	 * gameboard items populated with meaningful titles.
 	 * 
 	 * @param gameboards - list of gameboards to fully augment.
-	 * @return augmented gameboards as per inputted list.
 	 */
 	public void augmentGameboardItems(final List<GameboardDTO> gameboards) {
 		Set<String> questionIds = Sets.newHashSet();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
@@ -61,7 +61,7 @@ public class IsaacQuestionPage extends SeguePage {
     }
 
     public Float getPassMark() {
-        return this.passMark != null ? this.passMark : 100f;
+        return this.passMark;
     }
 
     public void setPassMark(Float passMark) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/IsaacQuestionPage.java
@@ -61,7 +61,7 @@ public class IsaacQuestionPage extends SeguePage {
     }
 
     public Float getPassMark() {
-        return passMark;
+        return this.passMark != null ? this.passMark : 100f;
     }
 
     public void setPassMark(Float passMark) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
@@ -186,17 +186,32 @@ public class GameboardItem {
 
     /**
      * Gets the passMark as a percentage.
+     *
      * @return the passMark as a percentage
      */
     public Float getPassMark() {
         return this.passMark;
     }
 
+    /**
+     * A method to check that all status fields are set to non-null values
+     *
+     * @return true if the status fields are all non-null
+     */
     private final boolean statusInformationIsNotNull() {
         return this.questionPartsCorrect != null && this.questionPartsIncorrect != null
                 && this.questionPartsNotAttempted != null && this.passMark != null;
     }
 
+    /**
+     * Sets status information for the object.
+     * Status results rely on all of these values being defined, hence why they are set together.
+     *
+     * @param questionPartsCorrect number of correct question parts
+     * @param questionPartsIncorrect number of incorrect question parts
+     * @param questionPartsNotAttempted number of question parts not attempted
+     * @param passMark pass mark as a percentage
+     */
     public final void setStatusInformation(final Integer questionPartsCorrect, final Integer questionPartsIncorrect,
                                            final Integer questionPartsNotAttempted, final Float passMark) {
         this.questionPartsCorrect = questionPartsCorrect;
@@ -218,7 +233,13 @@ public class GameboardItem {
         return result;
     }
 
-    public final Float calculatePercentageOfQuestionParts(Integer questionParts) {
+    /**
+     * Calculates the percentage ratio that the question parts argument represents for this question
+     *
+     * @param questionParts the number of question parts
+     * @return question part percentage
+     */
+    public final Float calculatePercentageOfQuestionParts(final Integer questionParts) {
         Float result = null;
         if (this.statusInformationIsNotNull()) {
             result = 100f * questionParts / this.getQuestionPartsTotal();
@@ -227,8 +248,8 @@ public class GameboardItem {
     }
 
     /**
-     * Gets the state.
-     * 
+     * Calculates and returns the state if the required fields have been set for the object.
+     *
      * @return the state
      */
     public final GameboardItemState getState() {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
@@ -194,11 +194,11 @@ public class GameboardItem {
     }
 
     /**
-     * A method to check that all status fields are set to non-null values
+     * Checks that all status fields are set to non-null values.
      *
      * @return true if the status fields are all non-null
      */
-    private final boolean statusInformationIsNotNull() {
+    private boolean statusInformationIsNotNull() {
         return this.questionPartsCorrect != null && this.questionPartsIncorrect != null
                 && this.questionPartsNotAttempted != null && this.passMark != null;
     }
@@ -234,12 +234,12 @@ public class GameboardItem {
     }
 
     /**
-     * Calculates the percentage ratio that the question parts argument represents for this question
+     * Calculates the percentage ratio that the question parts argument represents for this question.
      *
      * @param questionParts the number of question parts
      * @return question part percentage
      */
-    public final Float calculatePercentageOfQuestionParts(final Integer questionParts) {
+    public final Float calculateQuestionPartPercentage(final Integer questionParts) {
         Float result = null;
         if (this.statusInformationIsNotNull()) {
             result = 100f * questionParts / this.getQuestionPartsTotal();
@@ -256,12 +256,12 @@ public class GameboardItem {
         GameboardItemState state = null;
         if (this.statusInformationIsNotNull()) {
             Integer questionPartsTotal = this.getQuestionPartsTotal();
-            float percentCorrect = this.calculatePercentageOfQuestionParts(this.questionPartsCorrect);
-            float percentIncorrect = this.calculatePercentageOfQuestionParts(this.questionPartsIncorrect);
+            float percentCorrect = this.calculateQuestionPartPercentage(this.questionPartsCorrect);
+            float percentIncorrect = this.calculateQuestionPartPercentage(this.questionPartsIncorrect);
 
-            if (this.questionPartsCorrect == questionPartsTotal) {
+            if (this.questionPartsCorrect.equals(questionPartsTotal)) {
                 state = GameboardItemState.PERFECT;
-            } else if (this.questionPartsNotAttempted == questionPartsTotal) {
+            } else if (this.questionPartsNotAttempted.equals(questionPartsTotal)) {
                 state = GameboardItemState.NOT_ATTEMPTED;
             } else if (percentCorrect >= this.passMark) {
                 state = GameboardItemState.PASSED;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
@@ -218,6 +218,14 @@ public class GameboardItem {
         return result;
     }
 
+    public final Float calculatePercentageOfQuestionParts(Integer questionParts) {
+        Float result = null;
+        if (this.statusInformationIsNotNull()) {
+            result = 100f * questionParts / this.getQuestionPartsTotal();
+        }
+        return result;
+    }
+
     /**
      * Gets the state.
      * 
@@ -227,8 +235,8 @@ public class GameboardItem {
         GameboardItemState state = null;
         if (this.statusInformationIsNotNull()) {
             Integer questionPartsTotal = this.getQuestionPartsTotal();
-            float percentCorrect = 100 * (float) this.questionPartsCorrect / questionPartsTotal;
-            float percentIncorrect = 100 * (float) this.questionPartsIncorrect / questionPartsTotal;
+            float percentCorrect = this.calculatePercentageOfQuestionParts(this.questionPartsCorrect);
+            float percentIncorrect = this.calculatePercentageOfQuestionParts(this.questionPartsIncorrect);
 
             if (this.questionPartsCorrect == questionPartsTotal) {
                 state = GameboardItemState.PERFECT;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/GameboardItem.java
@@ -34,8 +34,11 @@ public class GameboardItem {
     private List<String> tags;
 
     private Integer level;
-    private GameboardItemState state;
-    
+    private Integer questionPartsCorrect;
+    private Integer questionPartsIncorrect;
+    private Integer questionPartsNotAttempted;
+    private Float passMark;
+
     // optional field if we want to use the gameboard item outside of the context of a board.
     @Nullable
     private String boardId;
@@ -155,22 +158,91 @@ public class GameboardItem {
     }
 
     /**
+     * Gets the number of questionPartsCorrect.
+     * 
+     * @return the number of questionPartsCorrect
+     */
+    public final Integer getQuestionPartsCorrect() {
+        return questionPartsCorrect;
+    }
+
+    /**
+     * Gets the number of questionPartsIncorrect.
+     * 
+     * @return the number of questionPartsIncorrect
+     */
+    public final Integer getQuestionPartsIncorrect() {
+        return questionPartsIncorrect;
+    }
+
+    /**
+     * Gets the number of questionPartsNotAttempted.
+     * 
+     * @return the number of questionPartsNotAttempted
+     */
+    public final Integer getQuestionPartsNotAttempted() {
+        return questionPartsNotAttempted;
+    }
+
+    /**
+     * Gets the passMark as a percentage.
+     * @return the passMark as a percentage
+     */
+    public Float getPassMark() {
+        return this.passMark;
+    }
+
+    private final boolean statusInformationIsNotNull() {
+        return this.questionPartsCorrect != null && this.questionPartsIncorrect != null
+                && this.questionPartsNotAttempted != null && this.passMark != null;
+    }
+
+    public final void setStatusInformation(final Integer questionPartsCorrect, final Integer questionPartsIncorrect,
+                                           final Integer questionPartsNotAttempted, final Float passMark) {
+        this.questionPartsCorrect = questionPartsCorrect;
+        this.questionPartsIncorrect = questionPartsIncorrect;
+        this.questionPartsNotAttempted = questionPartsNotAttempted;
+        this.passMark = passMark;
+    } 
+
+    /**
+     * Gets the number of total number of question parts.
+     * 
+     * @return the number of questionPartsTotal
+     */
+    public final Integer getQuestionPartsTotal() {
+        Integer result = null;
+        if (this.statusInformationIsNotNull()) {
+            result = this.questionPartsCorrect + this.questionPartsIncorrect + this.questionPartsNotAttempted;
+        }
+        return result;
+    }
+
+    /**
      * Gets the state.
      * 
      * @return the state
      */
     public final GameboardItemState getState() {
-        return state;
-    }
+        GameboardItemState state = null;
+        if (this.statusInformationIsNotNull()) {
+            Integer questionPartsTotal = this.getQuestionPartsTotal();
+            float percentCorrect = 100 * (float) this.questionPartsCorrect / questionPartsTotal;
+            float percentIncorrect = 100 * (float) this.questionPartsIncorrect / questionPartsTotal;
 
-    /**
-     * Sets the state.
-     * 
-     * @param state
-     *            the state to set
-     */
-    public final void setState(final GameboardItemState state) {
-        this.state = state;
+            if (this.questionPartsCorrect == questionPartsTotal) {
+                state = GameboardItemState.PERFECT;
+            } else if (this.questionPartsNotAttempted == questionPartsTotal) {
+                state = GameboardItemState.NOT_ATTEMPTED;
+            } else if (percentCorrect >= this.passMark) {
+                state = GameboardItemState.PASSED;
+            } else if (percentIncorrect > (100 - this.passMark)) {
+                state = GameboardItemState.FAILED;
+            } else {
+                state = GameboardItemState.IN_PROGRESS;
+            }
+        }
+        return state;
     }
 
     /**


### PR DESCRIPTION
First medium sized pull request to the API, so please talk me through any recommendations that you have so that I can match the codebase/Java's conventions and design decisions in the future.

Physicists want this information so that we can display question part progress as an extra column in the  Assignment Progress. This change sends the necessary information to the front-end and, as a bonus, calculates a better progress percentage for the My Boards page which uses question part progress rather than just question progress. 