### PR TITLE
Enable sorting gameboard results by title

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/GameboardsFacade.java
@@ -580,6 +580,8 @@ public class GameboardsFacade extends AbstractIsaacFacade {
                     parsedSortInstructions.add(immutableEntry(CREATED_DATE_FIELDNAME, s));
                 } else if (instruction.equals("visited")) {
                     parsedSortInstructions.add(immutableEntry(VISITED_DATE_FIELDNAME, s));
+                } else if (instruction.equals("title")) {
+                    parsedSortInstructions.add(immutableEntry(TITLE_FIELDNAME, s));
                 } else {
                     return new SegueErrorResponse(Status.BAD_REQUEST, "Sorry we do not recognise the sort instruction "
                             + instruction).toResponse();

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -380,6 +380,18 @@ public class GameManager {
                             return o1.getLastVisited().getTime() > o2.getLastVisited().getTime() ? -1 : 1;
                         }
                     }, reverseOrder);
+                }  else if (sortInstruction.getKey().equals(TITLE_FIELDNAME)) {
+                    comparatorForSorting.addComparator(new Comparator<GameboardDTO>() {
+                        public int compare(final GameboardDTO o1, final GameboardDTO o2) {
+                            if (o1.getTitle() == null) {
+                                return 1;
+                            }
+                            if (o2.getTitle() == null) {
+                                return -1;
+                            }
+                            return o1.getTitle().compareTo(o2.getTitle());
+                        }
+                    }, reverseOrder);
                 }
             }
         }


### PR DESCRIPTION
Following James' @jsharkey13 suggestion in isaac-app's issue 748.

We might get a chance to move the sorting to the DB when we add board search capabilities in the  near future. 