### PR TITLE
Hotfix/unknown tags in template

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -319,6 +319,10 @@ public class EventBookingManager {
                 emailManager.sendTemplatedEmailToUser(user,
                         emailManager.getEmailTemplateDTO("email-event-waiting-list-addition-notification"),
                         new ImmutableMap.Builder<String, Object>()
+                                .put("myBookedEventsURL", String.format("https://%s/events?show_booked_only=true",
+                                        propertiesLoader.getProperty(HOST_NAME)))
+                                .put("myAssignmentsURL", String.format("https://%s/assignments",
+                                        propertiesLoader.getProperty(HOST_NAME)))
                                 .put("contactUsURL", generateEventContactUsURL(event))
                                 .put("event.emailEventDetails", event.getEmailEventDetails() == null ? "" : event.getEmailEventDetails())
                                 .put("event", event)
@@ -605,6 +609,10 @@ public class EventBookingManager {
             emailManager.sendTemplatedEmailToUser(user,
                     emailManager.getEmailTemplateDTO("email-event-waiting-list-addition-notification"),
                     new ImmutableMap.Builder<String, Object>()
+                            .put("myBookedEventsURL", String.format("https://%s/events?show_booked_only=true",
+                                    propertiesLoader.getProperty(HOST_NAME)))
+                            .put("myAssignmentsURL", String.format("https://%s/assignments",
+                                    propertiesLoader.getProperty(HOST_NAME)))
                             .put("contactUsURL", generateEventContactUsURL(event))
                             .put("event.emailEventDetails", event.getEmailEventDetails() == null ? "" : event.getEmailEventDetails())
                             .put("event", event)

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/comm/EmailManager.java
@@ -504,7 +504,7 @@ public class EmailManager extends AbstractCommunicationQueue<EmailCommunicationM
                                                              EmailTemplateDTO emailContent, Properties contentProperties,
                                                              final EmailType emailType)
             throws ContentManagerException, ResourceNotFoundException {
-        return this.constructMultiPartEmail(userId, userEmail, emailContent, contentProperties, emailType);
+        return this.constructMultiPartEmail(userId, userEmail, emailContent, contentProperties, emailType, null);
     }
 
     /**


### PR DESCRIPTION
Adds tags to the context for the template.

Also, when looking over recent code changes I noticed that constructMultiPartEmail(...x5) was making a recursive call and nothing else (only used by getEmailInBrowserById(...)).

Could possibly release these fixes early (tomorrow).