### PR TITLE
Feature/recursively populate related content

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
@@ -290,16 +290,24 @@ public class ContentMapper {
         return mapOfDOsToDTOs.get(cls);
     }
 
-    // TODO MT JAVA DOC?
-    private void populateRelatedContentWithIDs(final ContentBase contentBase, final ContentBaseDTO resultBase) {
-        Content content = (Content) contentBase;
-        ContentDTO result = (ContentDTO) resultBase;
-
+    /**
+     * Populate relatedContent fields on the result and its children with IDs recursively.
+     * Only recurses to children of type Content, but this is currently the only possibility.
+     * When another subclass of ContentBase is introduced which also has relatedContent,
+     * we can decide whether we want to move relatedContent up to the abstract base class etc.
+     * @param content
+     *            - DO class.
+     * @param result
+     *            - target DTO class.
+     */
+    private void populateRelatedContentWithIDs(final Content content, final ContentDTO result) {
         List<ContentBase> contentChildren = content.getChildren();
         if (contentChildren != null) {
             List<ContentBaseDTO> resultChildren = result.getChildren();
             for (int i = 0; i < contentChildren.size(); i++) {
-                this.populateRelatedContentWithIDs(contentChildren.get(i), resultChildren.get(i));
+                if (contentChildren.get(i) instanceof Content && resultChildren.get(i) instanceof ContentDTO) {
+                    this.populateRelatedContentWithIDs((Content) contentChildren.get(i), (ContentDTO) resultChildren.get(i));
+                }
             }
         }
         if (result.getRelatedContent() != null) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/ContentMapper.java
@@ -305,8 +305,10 @@ public class ContentMapper {
         if (contentChildren != null) {
             List<ContentBaseDTO> resultChildren = result.getChildren();
             for (int i = 0; i < contentChildren.size(); i++) {
-                if (contentChildren.get(i) instanceof Content && resultChildren.get(i) instanceof ContentDTO) {
-                    this.populateRelatedContentWithIDs((Content) contentChildren.get(i), (ContentDTO) resultChildren.get(i));
+                ContentBase contentChild = contentChildren.get(i);
+                ContentBaseDTO resultChild = resultChildren.get(i);
+                if (contentChild instanceof Content && resultChild instanceof ContentDTO) {
+                    this.populateRelatedContentWithIDs((Content) contentChild, (ContentDTO) resultChild);
                 }
             }
         }
@@ -323,7 +325,7 @@ public class ContentMapper {
 
     /**
      * Find the default DTO class from a given Domain object.
-     * 
+     *
      * @param content
      *            - Content DO to map to DTO.
      * @return DTO that can be used for mapping.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -46,6 +46,7 @@ import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.database.GitDb;
 import uk.ac.cam.cl.dtg.segue.dos.content.*;
 import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
+import uk.ac.cam.cl.dtg.segue.dto.content.ContentBaseDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentSummaryDTO;
 import uk.ac.cam.cl.dtg.segue.search.AbstractFilterInstruction;
@@ -455,6 +456,12 @@ public class GitContentManager implements IContentManager {
     @Override
     public ContentDTO populateRelatedContent(final String version, final ContentDTO contentDTO)
             throws ContentManagerException {
+        if (contentDTO.getChildren() != null) {
+            for (ContentBaseDTO childBaseContentDTO : contentDTO.getChildren()) {
+                ContentDTO childContentDTO = (ContentDTO) childBaseContentDTO;
+                this.populateRelatedContent(version, childContentDTO);
+            }
+        }
         if (contentDTO.getRelatedContent() == null || contentDTO.getRelatedContent().isEmpty()) {
             return contentDTO;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -458,8 +458,9 @@ public class GitContentManager implements IContentManager {
             throws ContentManagerException {
         if (contentDTO.getChildren() != null) {
             for (ContentBaseDTO childBaseContentDTO : contentDTO.getChildren()) {
-                ContentDTO childContentDTO = (ContentDTO) childBaseContentDTO;
-                this.populateRelatedContent(version, childContentDTO);
+                if (childBaseContentDTO instanceof ContentDTO) {
+                    this.populateRelatedContent(version, (ContentDTO) childContentDTO);
+                }
             }
         }
         if (contentDTO.getRelatedContent() == null || contentDTO.getRelatedContent().isEmpty()) {


### PR DESCRIPTION
As a step toward fasttrack question-parts having related questions in the relatedContent, these changes populate the relatedContent fields of the content object and its children rather than just the top-level content object.

The main changes are:

1. Part of ContentMapper.getDTOByDO(...) has been pulled out into a separate method ContentMapper.populateRelatedContentWithIDs(...) which is recursively applied to the content and its children.

2. GitContentManager.populateRelatedContent(...) has been modified so that it is also applied to each of the content object's children.
 
The other changes are recommendations form the style checker.

Content and ContentDTO children are currently ContentBase and ContentBaseDTOs respectively. I am currently casting them if they are of sub-type Content and ContentDTO, which is fine until we have another class which inherits from ContentBaseDTO. This allows us to decide at that later point whether to force Content children to be of type Content or move related content up to the ContentBase etc.