### PR TITLE
Issue/isaac app 884/auto remove event related group

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -757,46 +757,47 @@ public class AssignmentFacade extends AbstractIsaacFacade {
      * 
      * @param request
      *            - so that we can identify the current user.
-     * @param gameboardId
-     *            - board to assign
-     * @param groupId
-     *            - assignee group
+     * @param assignmentDTOFromClient a partially completed DTO for the assignment.
      * @return the assignment object.
      */
     @POST
-    @Path("/assign/{gameboard_id}/{group_id}")
+    @Path("/assign/")
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
     public Response assignGameBoard(@Context final HttpServletRequest request,
-            @PathParam("gameboard_id") final String gameboardId, @PathParam("group_id") final Long groupId) {
+            final AssignmentDTO assignmentDTOFromClient) {
+
+        if (assignmentDTOFromClient.getGameboardId() == null || assignmentDTOFromClient.getGroupId() == null) {
+            return new SegueErrorResponse(Status.BAD_REQUEST, "A required field was missing. Must provide group and gameboard ids").toResponse();
+        }
+
         try {
             RegisteredUserDTO currentlyLoggedInUser = userManager.getCurrentRegisteredUser(request);
-            UserGroupDTO assigneeGroup = groupManager.getGroupById(groupId);
+            UserGroupDTO assigneeGroup = groupManager.getGroupById(assignmentDTOFromClient.getGroupId());
             if (null == assigneeGroup) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "The group id specified does not exist.")
                         .toResponse();
             }
 
-            GameboardDTO gameboard = this.gameManager.getGameboard(gameboardId);
+            GameboardDTO gameboard = this.gameManager.getGameboard(assignmentDTOFromClient.getGameboardId());
             if (null == gameboard) {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "The gameboard id specified does not exist.")
                         .toResponse();
             }
 
-            AssignmentDTO newAssignment = new AssignmentDTO();
-            newAssignment.setGameboardId(gameboard.getId());
-            newAssignment.setOwnerUserId(currentlyLoggedInUser.getId());
-            newAssignment.setGroupId(groupId);
+            assignmentDTOFromClient.setOwnerUserId(currentlyLoggedInUser.getId());
+            assignmentDTOFromClient.setCreationDate(null);
+            assignmentDTOFromClient.setId(null);
 
             // modifies assignment passed in to include an id.
-            AssignmentDTO assignmentWithID = this.assignmentManager.createAssignment(newAssignment);
+            AssignmentDTO assignmentWithID = this.assignmentManager.createAssignment(assignmentDTOFromClient);
 
             this.getLogManager().logEvent(currentlyLoggedInUser, request, SET_NEW_ASSIGNMENT,
                     ImmutableMap.of(Constants.GAMEBOARD_ID_FKEY, assignmentWithID.getGameboardId(),
                                     GROUP_FK, assignmentWithID.getGroupId(),
                                     ASSIGNMENT_FK, assignmentWithID.getId()));
 
-            return Response.ok(newAssignment).build();
+            return Response.ok(assignmentDTOFromClient).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
         } catch (DuplicateAssignmentException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/EventsFacade.java
@@ -811,7 +811,10 @@ public class EventsFacade extends AbstractIsaacFacade {
                 return new SegueErrorResponse(Status.BAD_REQUEST, "User is not booked on this event.").toResponse();
             }
 
-            bookingManager.deleteBooking(eventId, userId);
+            IsaacEventPageDTO event = this.getEventDTOById(request, eventId);
+            RegisteredUserDTO user = this.userManager.getUserDTOById(userId);
+
+            bookingManager.deleteBooking(event, user);
 
             this.getLogManager().logEvent(userManager.getCurrentUser(request), request,
                     Constants.ADMIN_EVENT_BOOKING_DELETED, ImmutableMap.of(EVENT_ID_FKEY_FIELDNAME, eventId, USER_ID_FKEY_FIELDNAME, userId));
@@ -823,6 +826,12 @@ public class EventsFacade extends AbstractIsaacFacade {
             String errorMsg = "Database error occurred while trying to delete an event booking.";
             log.error(errorMsg, e);
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, errorMsg).toResponse();
+        } catch (NoUserException e) {
+            return SegueErrorResponse.getResourceNotFoundResponse("Unable to locate user specified.");
+        } catch (ContentManagerException e) {
+            log.error("Error during event request", e);
+            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error locating the content you requested.")
+                    .toResponse();
         }
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -28,6 +28,7 @@ import uk.ac.cam.cl.dtg.isaac.dao.EventBookingPersistenceManager;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.BookingStatus;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.eventbookings.EventBookingDTO;
+import uk.ac.cam.cl.dtg.segue.api.managers.GroupManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
 import uk.ac.cam.cl.dtg.segue.comm.EmailAttachment;
 import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
@@ -37,8 +38,10 @@ import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.associations.InvalidUserAssociationTokenException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
+import uk.ac.cam.cl.dtg.segue.dos.AssociationToken;
 import uk.ac.cam.cl.dtg.segue.dos.users.EmailVerificationStatus;
 import uk.ac.cam.cl.dtg.segue.dos.users.Role;
+import uk.ac.cam.cl.dtg.segue.dto.UserGroupDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
@@ -61,6 +64,7 @@ public class EventBookingManager {
     private final EmailManager emailManager;
     private final UserAssociationManager userAssociationManager;
     private final PropertiesLoader propertiesLoader;
+    private final GroupManager groupManager;
 
     /**
      * EventBookingManager.
@@ -73,11 +77,13 @@ public class EventBookingManager {
     public EventBookingManager(final EventBookingPersistenceManager bookingPersistenceManager,
                                final EmailManager emailManager,
                                final UserAssociationManager userAssociationManager,
-                               final PropertiesLoader propertiesLoader) {
+                               final PropertiesLoader propertiesLoader,
+                               final GroupManager groupManager) {
         this.bookingPersistenceManager = bookingPersistenceManager;
         this.emailManager = emailManager;
         this.userAssociationManager = userAssociationManager;
         this.propertiesLoader = propertiesLoader;
+        this.groupManager = groupManager;
     }
 
     /**
@@ -544,6 +550,9 @@ public class EventBookingManager {
                             .build(),
                     EmailType.SYSTEM);
 
+            // auto remove them from the group
+            this.removeUserFromEventGroup(event, user);
+
         } finally {
             this.bookingPersistenceManager.releaseDistributedLock(event.getId());
         }
@@ -552,17 +561,20 @@ public class EventBookingManager {
     /**
      * Delete a booking permanently.
      *
-     * @param eventId - event id
-     * @param userId  - user id to unbook
+     * @param event - event context
+     * @param user  - user to unbook
      * @throws SegueDatabaseException - if an error occurs.
      */
-    public void deleteBooking(final String eventId, final Long userId) throws SegueDatabaseException {
+    public void deleteBooking(final IsaacEventPageDTO event, final RegisteredUserDTO user) throws SegueDatabaseException {
         try {
             // Obtain an exclusive database lock to lock the booking
-            this.bookingPersistenceManager.acquireDistributedLock(eventId);
-            this.bookingPersistenceManager.deleteBooking(eventId, userId);
+            this.bookingPersistenceManager.acquireDistributedLock(event.getId());
+            this.bookingPersistenceManager.deleteBooking(event.getId(), user.getId());
+
+            this.removeUserFromEventGroup(event, user);
+
         } finally {
-            this.bookingPersistenceManager.releaseDistributedLock(eventId);
+            this.bookingPersistenceManager.releaseDistributedLock(event.getId());
         }
     }
 
@@ -749,6 +761,29 @@ public class EventBookingManager {
         } catch (UnsupportedEncodingException e) {
             log.error("Unable to encode url for contact us link, using default url instead", e);
             return defaultURL;
+        }
+    }
+
+    /**
+     * Helper method to undo the group association made when a user books on an event.
+     * @param event context
+     * @param user to remove
+     * @throws SegueDatabaseException if there is a database error.
+     */
+    private void removeUserFromEventGroup(final IsaacEventPageDTO event, final RegisteredUserDTO user)
+            throws SegueDatabaseException{
+        try {
+            // auto remove them from the group
+            if (event.getIsaacGroupToken() != null) {
+                AssociationToken associationToken = this.userAssociationManager.lookupTokenDetails(user, event.getIsaacGroupToken());
+                UserGroupDTO group = this.groupManager.getGroupById(associationToken.getGroupId());
+                if (group != null) {
+                    this.groupManager.removeUserFromGroup(group, user);
+                }
+            }
+        } catch (InvalidUserAssociationTokenException e) {
+            log.error(String.format("Unable to auto remove user (%s) using token (%s) as the token is invalid.",
+                    user.getEmail(), event.getIsaacGroupToken()));
         }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -183,10 +183,6 @@ public class EventBookingManager {
             emailManager.sendTemplatedEmailToUser(user,
                     emailManager.getEmailTemplateDTO("email-event-booking-confirmed"),
                     new ImmutableMap.Builder<String, Object>()
-                            .put("myBookedEventsURL", String.format("https://%s/events?show_booked_only=true",
-                                    propertiesLoader.getProperty(HOST_NAME)))
-                            .put("myAssignmentsURL", String.format("https://%s/assignments",
-                                    propertiesLoader.getProperty(HOST_NAME)))
                             .put("contactUsURL", generateEventContactUsURL(event))
                             .put("authorizationLink", String.format("https://%s/account?authToken=%s",
                                     propertiesLoader.getProperty(HOST_NAME), event.getIsaacGroupToken()))
@@ -197,7 +193,7 @@ public class EventBookingManager {
                     Arrays.asList(generateEventICSFile(event, booking)));
         
         } catch (ContentManagerException e) {
-            log.error(String.format("Unable to send welcome email (%s) to user (%s)", event.getId(), user
+            log.error(String.format("Unable to send booking confirmation email (%s) to user (%s)", event.getId(), user
                     .getEmail()), e);
 
         } finally {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgAssignmentPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/PgAssignmentPersistenceManager.java
@@ -15,12 +15,7 @@
  */
 package uk.ac.cam.cl.dtg.isaac.dao;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -71,8 +66,8 @@ public class PgAssignmentPersistenceManager implements IAssignmentPersistenceMan
         try (Connection conn = database.getDatabaseConnection()) {
             pst = conn
                     .prepareStatement(
-                            "INSERT INTO assignments(gameboard_id, group_id, owner_user_id, creation_date)"
-                            + " VALUES (?, ?, ?, ?);",
+                            "INSERT INTO assignments(gameboard_id, group_id, owner_user_id, creation_date, due_date)"
+                            + " VALUES (?, ?, ?, ?, ?);",
                             Statement.RETURN_GENERATED_KEYS);
 
             pst.setString(1, assignmentToSave.getGameboardId());
@@ -83,6 +78,12 @@ public class PgAssignmentPersistenceManager implements IAssignmentPersistenceMan
                 pst.setTimestamp(4, new java.sql.Timestamp(assignmentToSave.getCreationDate().getTime()));
             } else {
                 pst.setTimestamp(4, new java.sql.Timestamp(new Date().getTime()));
+            }
+
+            if (assignment.getDueDate() != null) {
+                pst.setTimestamp(5, new java.sql.Timestamp(assignmentToSave.getDueDate().getTime()));
+            } else {
+                pst.setNull(5, Types.TIMESTAMP);
             }
 
             if (pst.executeUpdate() == 0) {
@@ -276,7 +277,14 @@ public class PgAssignmentPersistenceManager implements IAssignmentPersistenceMan
      */
     private AssignmentDO convertFromSQLToAssignmentDO(final ResultSet sqlResults) throws SQLException {
         java.util.Date preciseDate = new java.util.Date(sqlResults.getTimestamp("creation_date").getTime());
+
+        java.util.Date preciseDueDate = null;
+        if (sqlResults.getTimestamp("due_date") != null) {
+            preciseDueDate = new java.util.Date(sqlResults.getTimestamp("due_date").getTime());
+        }
+
         return new AssignmentDO(sqlResults.getLong("id"), sqlResults.getString("gameboard_id"),
-                sqlResults.getLong("owner_user_id"), sqlResults.getLong("group_id"), preciseDate);
+                sqlResults.getLong("owner_user_id"), sqlResults.getLong("group_id"), preciseDate,
+                preciseDueDate);
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssignmentDO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dos/AssignmentDO.java
@@ -32,7 +32,8 @@ public class AssignmentDO {
 	private Long groupId;
 	private Long ownerUserId;
 	private Date creationDate;
-	
+	private Date dueDate;
+
 	/**
 	 * Complete AssignmentDO constructor with all dependencies.
 	 * 
@@ -46,14 +47,17 @@ public class AssignmentDO {
 	 *            - Group id who should be assigned the game board.
 	 * @param creationDate
 	 *            - the date the assignment was created.
+	 * @param dueDate
+	 *            - the date the assignment should be completed by.
 	 */
     public AssignmentDO(final Long id, final String gameboardId, final Long ownerUserId, final Long groupId,
-            final Date creationDate) {
+            final Date creationDate, final Date dueDate) {
 		this.id = id;
 		this.gameboardId = gameboardId;
 		this.ownerUserId = ownerUserId;
 		this.groupId = groupId;
 		this.creationDate = creationDate;
+		this.dueDate = dueDate;
 	}
 	
 	/**
@@ -176,4 +180,20 @@ public class AssignmentDO {
 		}
         return true;
     }
+
+	/**
+	 * get the due date of the assignment
+	 * @return
+	 */
+	public Date getDueDate() {
+		return dueDate;
+	}
+
+	/**
+	 * set the due date of an assignment
+	 * @param dueDate
+	 */
+	public void setDueDate(Date dueDate) {
+		this.dueDate = dueDate;
+	}
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/AssignmentDTO.java
@@ -36,6 +36,7 @@ public class AssignmentDTO {
     private Long ownerUserId;
     private UserSummaryDTO assignerSummary;
     private Date creationDate;
+    private Date dueDate;
 
     /**
      * Complete AssignmentDTO constructor with all dependencies.
@@ -50,14 +51,17 @@ public class AssignmentDTO {
      *            - Group id who should be assigned the game board.
      * @param creationDate
      *            - the date the assignment was created.
+     * @param dueDate
+     *            - the date the assignment should be completed by
      */
     public AssignmentDTO(final Long id, final String gameboardId, final Long ownerUserId, final Long groupId,
-            final Date creationDate) {
+            final Date creationDate, final Date dueDate) {
         this.id = id;
         this.gameboardId = gameboardId;
         this.ownerUserId = ownerUserId;
         this.groupId = groupId;
         this.creationDate = creationDate;
+        this.dueDate = dueDate;
     }
 
     /**
@@ -199,5 +203,21 @@ public class AssignmentDTO {
      */
     public void setCreationDate(final Date creationDate) {
         this.creationDate = creationDate;
+    }
+
+    /**
+     * get the due date of the assignment
+     * @return
+     */
+    public Date getDueDate() {
+        return dueDate;
+    }
+
+    /**
+     * set the due date of an assignment
+     * @param dueDate
+     */
+    public void setDueDate(Date dueDate) {
+        this.dueDate = dueDate;
     }
 }

--- a/src/main/resources/db_scripts/assignment_due_date_upgrade.sql
+++ b/src/main/resources/db_scripts/assignment_due_date_upgrade.sql
@@ -1,0 +1,6 @@
+-- Column: due_date
+
+-- ALTER TABLE public.assignments DROP COLUMN due_date;
+
+ALTER TABLE public.assignments ADD COLUMN due_date timestamp with time zone;
+

--- a/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
+++ b/src/main/resources/db_scripts/postgres-rutherford-create-script.sql
@@ -137,7 +137,8 @@ CREATE TABLE assignments (
     gameboard_id character varying(255) NOT NULL,
     group_id integer NOT NULL,
     owner_user_id integer,
-    creation_date timestamp without time zone
+    creation_date timestamp without time zone,
+    due_date timestamp with time zone
 );
 
 

--- a/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManagerTest.java
@@ -8,6 +8,7 @@ import uk.ac.cam.cl.dtg.isaac.dao.EventBookingPersistenceManager;
 import uk.ac.cam.cl.dtg.isaac.dos.eventbookings.BookingStatus;
 import uk.ac.cam.cl.dtg.isaac.dto.IsaacEventPageDTO;
 import uk.ac.cam.cl.dtg.isaac.dto.eventbookings.EventBookingDTO;
+import uk.ac.cam.cl.dtg.segue.api.managers.GroupManager;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAssociationManager;
 import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
 import uk.ac.cam.cl.dtg.segue.comm.EmailMustBeVerifiedException;
@@ -37,6 +38,7 @@ public class EventBookingManagerTest {
     private UserAssociationManager userAssociationManager;
     private Map<String, String> someAdditionalInformation;
     private PropertiesLoader dummyPropertiesLoader;
+    private GroupManager groupManager;
 
     /**
      * Initial configuration of tests.
@@ -48,6 +50,7 @@ public class EventBookingManagerTest {
         this.dummyEmailManager = createMock(EmailManager.class);
         this.dummyEventBookingPersistenceManager = createMock(EventBookingPersistenceManager.class);
         this.userAssociationManager = createMock(UserAssociationManager.class);
+        this.groupManager = createMock(GroupManager.class);
         this.dummyPropertiesLoader = createMock(PropertiesLoader.class);
         expect(this.dummyPropertiesLoader.getProperty(HOST_NAME)).andReturn("hostname.com").anyTimes();
         this.someAdditionalInformation = Maps.newHashMap();
@@ -517,6 +520,6 @@ public class EventBookingManagerTest {
     }
 
     private EventBookingManager buildEventBookingManager() {
-        return new EventBookingManager(dummyEventBookingPersistenceManager, dummyEmailManager, userAssociationManager, dummyPropertiesLoader);
+        return new EventBookingManager(dummyEventBookingPersistenceManager, dummyEmailManager, userAssociationManager, dummyPropertiesLoader, groupManager);
     }
 }


### PR DESCRIPTION
This change allows the api to auto remove users from a group when their event booking has been cancelled. Teacher connections still persist as there is a chance they may want to manually control these.