### PR TITLE
Add IP based rate limiting

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/QuestionFacade.java
@@ -29,6 +29,7 @@ import uk.ac.cam.cl.dtg.segue.api.managers.SegueResourceMisuseException;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.monitors.AnonQuestionAttemptMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.IMisuseMonitor;
+import uk.ac.cam.cl.dtg.segue.api.monitors.IPQuestionAttemptMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.api.monitors.QuestionAttemptMisuseHandler;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
@@ -44,6 +45,7 @@ import uk.ac.cam.cl.dtg.segue.dto.users.AbstractSegueUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
+import uk.ac.cam.cl.dtg.util.RequestIPExtractor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
@@ -187,6 +189,7 @@ public class QuestionFacade extends AbstractSegueFacade {
             // We store response.getEntity() in either case so that we can treat them the same in later analysis.
             if (currentUser instanceof RegisteredUserDTO) {
                 try {
+                    // Monitor misuse on a per-question per-registered user basis, with higher limits:
                     misuseMonitor.notifyEvent(((RegisteredUserDTO) currentUser).getId().toString() + "|" + questionId,
                             QuestionAttemptMisuseHandler.class.toString());
                 } catch (SegueResourceMisuseException e) {
@@ -196,11 +199,24 @@ public class QuestionFacade extends AbstractSegueFacade {
                 }
             } else {
                 try {
+                    // Monitor misuse on a per-question per-anonymous user basis:
                     misuseMonitor.notifyEvent(((AnonymousUserDTO) currentUser).getSessionId() + "|" + questionId,
                             AnonQuestionAttemptMisuseHandler.class.toString());
                 } catch (SegueResourceMisuseException e) {
                     this.getLogManager().logEvent(currentUser, request, QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
                     String message = "You have made too many attempts at this question part. Please log in or try again later.";
+                    return SegueErrorResponse.getRateThrottledResponse(message);
+                }
+                try {
+                    // And monitor on a blanket per IP Address basis for non-logged in users.
+                    // If we see serious misuse, this could be moved to *before* the attempt validation and checking,
+                    // to save server load. Since this occurs after the anon user notify event, that will catch most
+                    // misuse and this will catch misuse ignoring cookies or with repeated new anon accounts.
+                    misuseMonitor.notifyEvent(RequestIPExtractor.getClientIpAddr(request),
+                            IPQuestionAttemptMisuseHandler.class.toString());
+                } catch (SegueResourceMisuseException e) {
+                    this.getLogManager().logEvent(currentUser, request, QUESTION_ATTEMPT_RATE_LIMITED, response.getEntity());
+                    String message = "Too many question attempts! Please log in or try again later.";
                     return SegueErrorResponse.getRateThrottledResponse(message);
                 }
             }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/AnonQuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/AnonQuestionAttemptMisuseHandler.java
@@ -19,11 +19,6 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.comm.EmailCommunicationMessage;
-import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
-import uk.ac.cam.cl.dtg.segue.comm.EmailType;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 public class AnonQuestionAttemptMisuseHandler implements IMisuseHandler {
 
@@ -55,7 +50,8 @@ public class AnonQuestionAttemptMisuseHandler implements IMisuseHandler {
     }
 
     @Override
-    public void executeSoftThresholdAction(final String message) {}
+    public void executeSoftThresholdAction(final String message) {
+    }
 
     @Override
     public void executeHardThresholdAction(final String message) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IPQuestionAttemptMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/IPQuestionAttemptMisuseHandler.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2017 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.api.monitors;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
+import uk.ac.cam.cl.dtg.segue.comm.EmailCommunicationMessage;
+import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
+import uk.ac.cam.cl.dtg.segue.comm.EmailType;
+import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
+import uk.ac.cam.cl.dtg.util.PropertiesLoader;
+
+public class IPQuestionAttemptMisuseHandler implements IMisuseHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(IPQuestionAttemptMisuseHandler.class);
+
+    private static final Integer SOFT_THRESHOLD = 120;  // Two attempts minute for an hour, or 24 anonymous users.
+    private static final Integer HARD_THRESHOLD = 1200;  // One every three seconds for an hour; far too high!
+    private static final Integer ACCOUNTING_INTERVAL = Constants.NUMBER_SECONDS_IN_ONE_HOUR;
+
+    private PropertiesLoader properties;
+    private EmailManager emailManager;
+
+    /**
+     * @param emailManager
+     *            - so we can send e-mails if the threshold limits have been reached.
+     * @param properties
+     *            - so that we can look up properties set.
+     */
+    @Inject
+    public IPQuestionAttemptMisuseHandler(final EmailManager emailManager, final PropertiesLoader properties) {
+        this.properties = properties;
+        this.emailManager = emailManager;
+    }
+
+    @Override
+    public Integer getSoftThreshold() {
+        return SOFT_THRESHOLD;
+    }
+
+    @Override
+    public Integer getHardThreshold() {
+        return HARD_THRESHOLD;
+    }
+
+    @Override
+    public Integer getAccountingIntervalInSeconds() {
+        return ACCOUNTING_INTERVAL;
+    }
+
+    @Override
+    public void executeSoftThresholdAction(final String message) {
+        log.warn("Too many requests from an IP Address: " + message);
+    }
+
+    @Override
+    public void executeHardThresholdAction(final String message) {
+        final String subject = "HARD Threshold limit reached for IP Address based Question Attempts!";
+        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
+                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
+                null, null, null);
+        try {
+            emailManager.addSystemEmailToQueue(e);
+        } catch (SegueDatabaseException e1) {
+            log.error("Database error when attempting to send threshold limit warnings: " + e1.getMessage());
+        }
+        log.warn("Too many requests from an IP Address: " + message + " This may be a scripted attack!");
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueLoginMisuseHandler.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/monitors/SegueLoginMisuseHandler.java
@@ -19,10 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.ac.cam.cl.dtg.segue.api.Constants;
-import uk.ac.cam.cl.dtg.segue.comm.EmailCommunicationMessage;
 import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
-import uk.ac.cam.cl.dtg.segue.comm.EmailType;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import com.google.inject.Inject;
@@ -82,18 +79,6 @@ public class SegueLoginMisuseHandler implements IMisuseHandler {
 
     @Override
     public void executeHardThresholdAction(final String message) {
-        final String subject = "HARD Threshold limit reached for LoginMisuseHandler";
-
-        EmailCommunicationMessage e = new EmailCommunicationMessage(null,
-                properties.getProperty(Constants.SERVER_ADMIN_ADDRESS), subject, message, message, EmailType.ADMIN,
-                null, null, null);
-
-        try {
-			emailManager.addSystemEmailToQueue(e);
-		} catch (SegueDatabaseException e1) {
-			log.error("Database access error when attempting to send hard threshold limit warnings: " 
-								+ e1.getMessage());
-		}
         log.warn("Hard threshold limit: " + message);
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -37,16 +37,7 @@ import org.slf4j.LoggerFactory;
 import uk.ac.cam.cl.dtg.isaac.api.managers.GameManager;
 import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.api.managers.*;
-import uk.ac.cam.cl.dtg.segue.api.monitors.EmailVerificationMisuseHandler;
-import uk.ac.cam.cl.dtg.segue.api.monitors.EmailVerificationRequestMisuseHandler;
-import uk.ac.cam.cl.dtg.segue.api.monitors.IMisuseMonitor;
-import uk.ac.cam.cl.dtg.segue.api.monitors.InMemoryMisuseMonitor;
-import uk.ac.cam.cl.dtg.segue.api.monitors.LogEventMisuseHandler;
-import uk.ac.cam.cl.dtg.segue.api.monitors.PasswordResetRequestMisuseHandler;
-import uk.ac.cam.cl.dtg.segue.api.monitors.SegueLoginMisuseHandler;
-import uk.ac.cam.cl.dtg.segue.api.monitors.TokenOwnerLookupMisuseHandler;
-import uk.ac.cam.cl.dtg.segue.api.monitors.QuestionAttemptMisuseHandler;
-import uk.ac.cam.cl.dtg.segue.api.monitors.AnonQuestionAttemptMisuseHandler;
+import uk.ac.cam.cl.dtg.segue.api.monitors.*;
 import uk.ac.cam.cl.dtg.segue.auth.*;
 import uk.ac.cam.cl.dtg.segue.comm.EmailCommunicator;
 import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
@@ -592,6 +583,9 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
 
             misuseMonitor.registerHandler(AnonQuestionAttemptMisuseHandler.class.toString(),
                     new AnonQuestionAttemptMisuseHandler());
+
+            misuseMonitor.registerHandler(IPQuestionAttemptMisuseHandler.class.toString(),
+                    new IPQuestionAttemptMisuseHandler(emailManager, properties));
         }
 
         return misuseMonitor;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
@@ -44,8 +44,10 @@ import uk.ac.cam.cl.dtg.segue.dto.users.AbstractSegueUserDTO;
 
 import uk.ac.cam.cl.dtg.segue.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
+import uk.ac.cam.cl.dtg.util.RequestIPExtractor;
 
 import javax.servlet.http.HttpServletRequest;
+
 
 /**
  * Kafka logging listener
@@ -83,10 +85,10 @@ public class KafkaLoggingManager extends LoggingEventHandler {
         try {
             if (user instanceof RegisteredUserDTO) {
                 this.publishLogEvent(((RegisteredUserDTO) user).getId().toString(), null, eventType, eventDetails,
-                        getClientIpAddr(httpRequest));
+                        RequestIPExtractor.getClientIpAddr(httpRequest));
             } else {
                 this.publishLogEvent(null, ((AnonymousUserDTO) user).getSessionId(), eventType, eventDetails,
-                        getClientIpAddr(httpRequest));
+                        RequestIPExtractor.getClientIpAddr(httpRequest));
             }
 
         } catch (JsonProcessingException e) {
@@ -250,38 +252,6 @@ public class KafkaLoggingManager extends LoggingEventHandler {
         logEvent.setTimestamp(new Date());
 
         return logEvent;
-    }
-
-
-
-    /**
-     * Extract client ip address.
-     *
-     * Solution retrieved from:
-     * http://stackoverflow.com/questions/4678797/how-do-i-get-the-remote-address-of-a-client-in-servlet
-     *
-     * @param request
-     *            - to attempt to extract a valid Ip from.
-     * @return string representation of the client's ip address.
-     */
-    private static String getClientIpAddr(final HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("Proxy-Client-IP");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("WL-Proxy-Client-IP");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("HTTP_CLIENT_IP");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
-        }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getRemoteAddr();
-        }
-        return ip;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/util/RequestIPExtractor.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/util/RequestIPExtractor.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 James Sharkey
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ *  A utility class to extract IP addresses from HTTP requests.
+ */
+public final class RequestIPExtractor {
+    private static final Logger log = LoggerFactory.getLogger(RequestIPExtractor.class);
+
+    /**
+        It does not make sense to create one of these!
+     */
+    private RequestIPExtractor() {
+    }
+
+    /**
+     * Extract client ip address.
+     *
+     * Solution based upon:
+     * http://stackoverflow.com/questions/4678797/how-do-i-get-the-remote-address-of-a-client-in-servlet
+     *
+     * @param request
+     *            - to attempt to extract a valid IP address from.
+     * @return string representation of the client's ip address, or 0.0.0.0 in case of failure.
+     */
+    public static String getClientIpAddr(final HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip != null && ip.contains(",")) {
+            // If X-Forwarded-For contains multiple comma-separated IP addresses, we want only the last one.
+            log.debug("X-Forwarded-For contained multiple IP addresses, extracting last: '" + ip + "'");
+            ip = ip.substring(ip.lastIndexOf(',') + 1).trim();
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            // Isaac adds this custom header which could be used:
+            ip = request.getHeader("X-Real-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            // In production, this will usually be the router address which may be unhelpful.
+            ip = request.getRemoteAddr();
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            // We *must* return a *valid* inet field for postgres! Null would be
+            // acceptable, but is used for internal log events; 'unknown' is not allowed!
+            // So if all else fails, use the impossible source address '0.0.0.0' to mark this.
+            ip = "0.0.0.0";
+        }
+        return ip;
+    }
+}


### PR DESCRIPTION
After seeing a rise in misuse of our API by scripts which ignore cookies, add rate limiting on a per-IP address basis to prevent abuse of our services.
This will not affect a malicious or dedicated attacker, but will prevent basic scripts from attempting to guess answers. 
For further enhancements, we could treat users with verified email addresses differently and reduce the per IP limits too. Adding [rate limiting](https://www.nginx.com/blog/rate-limiting-nginx/) to our [nginx router](https://github.com/ucam-cl-dtg/isaac-router) would be the best method for a dedicated attack or persistent abuse.