### PR TITLE
Changes board percentage calculation to weigh all question parts equa…

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/GameManager.java
@@ -449,10 +449,10 @@ public class GameManager {
             return gameboardDTO;
         }
 
-        int totalUnavailable = 0;
         boolean gameboardStarted = false;
         List<GameboardItem> questions = gameboardDTO.getQuestions();
-        List<Float> questionPercentages = Lists.newArrayList();
+        int totalNumberOfQuestionsParts = 0;
+        int totalNumberOfCorrectQuestionParts = 0;
         for (GameboardItem gameItem : questions) {
             try {
                 this.augmentGameItemWithAttemptInformation(gameItem, questionAttemptsFromUser);
@@ -460,20 +460,16 @@ public class GameManager {
                 log.info(String.format(
                         "A question is unavailable (%s) - treating it as if it never existed for marking.",
                         gameItem.getId()));
-                totalUnavailable++;
                 continue;
             }
             if (!gameboardStarted && !gameItem.getState().equals(Constants.GameboardItemState.NOT_ATTEMPTED)) {
                 gameboardStarted = true;
                 gameboardDTO.setStartedQuestion(gameboardStarted);
             }
-            questionPercentages.add(
-                    100f * new Float(gameItem.getQuestionPartsCorrect()) / gameItem.getQuestionPartsTotal());
+            totalNumberOfQuestionsParts += gameItem.getQuestionPartsTotal();
+            totalNumberOfCorrectQuestionParts += gameItem.getQuestionPartsCorrect();
         }
-        int numberOfValidQuestions = questions.size() - totalUnavailable;
-        float boardPercentage = questionPercentages.stream()
-                .map(questionPercentage -> questionPercentage / numberOfValidQuestions)
-                .reduce(0f, (a, b) -> a + b);
+        float boardPercentage = 100f * totalNumberOfCorrectQuestionParts / totalNumberOfQuestionsParts;
         gameboardDTO.setPercentageCompleted((int) Math.round(boardPercentage));
         
         if (user instanceof RegisteredUserDTO) {


### PR DESCRIPTION
…lly to conform with assignment progress and csv percentages.

My previous implementation had it weighing each question page/hexagon equally rather than each question part equally. The problem with this was that it did not match the assignment progress and csv completion percentages. Oops, 👎!

Ultimately we should aim to have this calculation done in one place rather than here, at each csv export and on the assignment progress page front end. Currently the logic is quite tied up in the loops, especially the csv generating code. For now it is more important that their values match, but I'll add the refactoring as a task for the next release or two.