### PR TITLE
Fail early when invalid passwords are provided

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/UsersFacade.java
@@ -421,7 +421,7 @@ public class UsersFacade extends AbstractSegueFacade {
             log.error("Invalid password reset token supplied: " + token);
             return error.toResponse();
         } catch (InvalidPasswordException e) {
-            SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST, "No password supplied.");
+            SegueErrorResponse error = new SegueErrorResponse(Status.BAD_REQUEST, e.getMessage());
             return error.toResponse();
         } catch (SegueDatabaseException e) {
             String errorMsg = "Database error has occurred during reset password process. Please try again later";
@@ -778,8 +778,7 @@ public class UsersFacade extends AbstractSegueFacade {
             log.error("Unable to modify user", e);
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Error while modifying the user").toResponse();
         } catch (InvalidPasswordException e) {
-            return new SegueErrorResponse(Status.BAD_REQUEST, e.getMessage())
-                    .toResponse();
+            return new SegueErrorResponse(Status.BAD_REQUEST, e.getMessage()).toResponse();
         } catch (MissingRequiredFieldException e) {
             log.warn("Missing field during update operation. ", e);
             return new SegueErrorResponse(Status.BAD_REQUEST, "You are missing a required field. "

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -659,6 +659,9 @@ public class UserAccountManager {
             log.error("Creation of email verification token failed: " + e1.getMessage());
         }
 
+        // FIXME: Before creating the user object, ensure password is valid. This should really be in a transaction.
+        authenticator.ensureValidPassword(newPassword);
+
         // save the user to get the userId
         RegisteredUser userToReturn = this.database.createOrUpdateUser(userToSave);
 
@@ -734,6 +737,11 @@ public class UserAccountManager {
 
         IPasswordAuthenticator authenticator = (IPasswordAuthenticator) this.registeredAuthProviders
                 .get(AuthenticationProvider.SEGUE);
+
+        // Check if there is a new password and it is invalid as early as possible:
+        if (null != newPassword && !newPassword.isEmpty()) {
+            authenticator.ensureValidPassword(newPassword);
+        }
 
         // Send a new verification email if the user has changed their email
         if (!existingUser.getEmail().equals(updatedUser.getEmail())) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IPasswordAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/IPasswordAuthenticator.java
@@ -102,6 +102,15 @@ public interface IPasswordAuthenticator extends IAuthenticator {
     boolean isValidResetToken(final String token) throws SegueDatabaseException;
 
     /**
+     * This method will throw an exception for invalid passwords.
+     *
+     * @param password
+     *            - Password to validate.
+     * @throws InvalidPasswordException - if the password is invalid
+     */
+    void ensureValidPassword(final String password) throws InvalidPasswordException;
+
+    /**
      * This method will test if the user's reset token is valid reset token for a given user.
      *
      * @param token

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/auth/SegueLocalAuthenticator.java
@@ -89,13 +89,7 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
     @Override
     public void setOrChangeUsersPassword(final RegisteredUser userToSetPasswordFor, final String plainTextPassword)
             throws InvalidPasswordException, SegueDatabaseException {
-        if (null == plainTextPassword || plainTextPassword.isEmpty()) {
-            throw new InvalidPasswordException("Invalid password. You cannot have an empty password.");
-        }
-
-        if (plainTextPassword.length() < 6) {
-            throw new InvalidPasswordException("Password must be at least 6 characters in length.");
-        }
+        ensureValidPassword(plainTextPassword);
 
         this.updateUsersPasswordWithoutValidation(userToSetPasswordFor, plainTextPassword);
     }
@@ -245,6 +239,17 @@ public class SegueLocalAuthenticator implements IPasswordAuthenticator {
 
         // check the token matches and hasn't expired (I know that we have just looked it up but that might change so checking anyway)
         return luc.getResetToken().equals(token) && luc.getResetExpiry().after(now);
+    }
+
+    @Override
+    public void ensureValidPassword(final String password) throws InvalidPasswordException {
+        if (null == password || password.isEmpty()) {
+            throw new InvalidPasswordException("Invalid password. You cannot have an empty password.");
+        }
+
+        if (password.length() < 6) {
+            throw new InvalidPasswordException("Password must be at least 6 characters in length.");
+        }
     }
 
     @Override


### PR DESCRIPTION
This is the simplest possible change to prevent the non-atomic nature of update operations breaking things like registration if an exception occurs part way through. A better solution would be transactions on the database level to prevent an inconsistent state ever being created.

I used the exception-based control flow since this was what already happened and required the least modification to the code.