### PR TITLE
issue/isaac-app/891/Accessing state stores across kafka streams instances

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/KafkaStatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/KafkaStatisticsManager.java
@@ -107,12 +107,12 @@ public class KafkaStatisticsManager implements IStatisticsManager {
 
         // get user records from local kafka store
         // this is much faster than accessing postgres
-        ReadOnlyKeyValueStore<String, JsonNode> userStore = waitUntilStoreIsQueryable("store_user_data",
+        ReadOnlyKeyValueStore<String, JsonNode> userStore = waitUntilStoreIsQueryable("globalstore_user_data",
                     QueryableStoreTypes.<String, JsonNode>keyValueStore(),
                 statisticsStreamsApplication.getStream());
 
         // get user activity data from local kafka store
-        ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("store_user_last_seen",
+        ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("globalstore_user_last_seen",
                 QueryableStoreTypes.<String, JsonNode>keyValueStore(),
                 statisticsStreamsApplication.getStream());
 
@@ -352,7 +352,7 @@ public class KafkaStatisticsManager implements IStatisticsManager {
     @Override
     public Long getLogCount(final String logTypeOfInterest) throws InvalidStateStoreException {
 
-        ReadOnlyKeyValueStore<String, Long> logEventCounts = waitUntilStoreIsQueryable("store_log_event_counts",
+        ReadOnlyKeyValueStore<String, Long> logEventCounts = waitUntilStoreIsQueryable("globalstore_log_event_counts",
                 QueryableStoreTypes.<String, Long>keyValueStore(),
                 statisticsStreamsApplication.getStream());
 
@@ -456,12 +456,12 @@ public class KafkaStatisticsManager implements IStatisticsManager {
         try {
 
             // get user data from local kafka store
-            ReadOnlyKeyValueStore<String, JsonNode> userStore = waitUntilStoreIsQueryable("store_user_data",
+            ReadOnlyKeyValueStore<String, JsonNode> userStore = waitUntilStoreIsQueryable("globalstore_user_data",
                     QueryableStoreTypes.<String, JsonNode>keyValueStore(),
                     statisticsStreamsApplication.getStream());
 
             // get user activity data from local kafka store
-            ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("store_user_last_seen",
+            ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("globalstore_user_last_seen",
                     QueryableStoreTypes.<String, JsonNode>keyValueStore(),
                     statisticsStreamsApplication.getStream());
 
@@ -528,12 +528,12 @@ public class KafkaStatisticsManager implements IStatisticsManager {
         List<RegisteredUserDTO> users = Lists.newArrayList();
 
         // get user data from local kafka store
-        ReadOnlyKeyValueStore<String, JsonNode> userStore = waitUntilStoreIsQueryable("store_user_data",
+        ReadOnlyKeyValueStore<String, JsonNode> userStore = waitUntilStoreIsQueryable("globalstore_user_data",
                 QueryableStoreTypes.<String, JsonNode>keyValueStore(),
                 statisticsStreamsApplication.getStream());
 
         // get user activity data from local kafka store
-        ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("store_user_last_seen",
+        ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("globalstore_user_last_seen",
                 QueryableStoreTypes.<String, JsonNode>keyValueStore(),
                 statisticsStreamsApplication.getStream());
 
@@ -586,7 +586,7 @@ public class KafkaStatisticsManager implements IStatisticsManager {
 
         Map<String, Date> userMap = Maps.newHashMap();
 
-        ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("store_user_last_seen",
+        ReadOnlyKeyValueStore<String, JsonNode> userLastSeenStore = waitUntilStoreIsQueryable("globalstore_user_last_seen",
                 QueryableStoreTypes.<String, JsonNode>keyValueStore(),
                 statisticsStreamsApplication.getStream());
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
@@ -28,12 +28,14 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.commons.lang3.Validate;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.json.JsonDeserializer;
 import org.slf4j.Logger;
@@ -81,8 +83,15 @@ public class KafkaLoggingManager extends LoggingEventHandler {
         this.kafkaPort = kafkaPort;
 
         // ensure topics exist before attempting to consume
-        kafkaTopicManager.ensureTopicExists("topic_logged_events_test", -1);
-        kafkaTopicManager.ensureTopicExists("topic_anonymous_logged_events_test", 7200000);
+        // logged events
+        List<ConfigEntry> loggedEventsConfigs = Lists.newLinkedList();
+        loggedEventsConfigs.add(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(-1)));
+        kafkaTopicManager.ensureTopicExists("topic_anonymous_logged_events_test", loggedEventsConfigs);
+
+        // anonymous logged events
+        List<ConfigEntry> anonLoggedEventsConfigs = Lists.newLinkedList();
+        anonLoggedEventsConfigs.add(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(7200000)));
+        kafkaTopicManager.ensureTopicExists("topic_anonymous_logged_events_test", anonLoggedEventsConfigs);
     }
 
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/KafkaTopicManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/KafkaTopicManager.java
@@ -8,10 +8,7 @@ import org.apache.kafka.common.config.TopicConfig;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import javax.inject.Inject;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 public class KafkaTopicManager {
@@ -30,30 +27,23 @@ public class KafkaTopicManager {
      * Method to check if a topic exists inside Kafka, and to create it if not
      *
      * @param name name of the topic
-     * @param retentionMillis required retention period if topic requires creation
+     * @param configEntries specified configuration variables if topic requires creation
      */
-    public void ensureTopicExists(final String name, final long retentionMillis) {
+    public void ensureTopicExists(final String name, final Collection<ConfigEntry> configEntries) {
 
         try {
             if (!adminClient.listTopics().names().get().contains(name)) {
                 adminClient.createTopics(ImmutableList.of(new NewTopic(name, 1, Short.parseShort(globalProperties.getProperty("KAFKA_REPLICATION_FACTOR"))))).all().get();
 
-                if (retentionMillis != 0) {
+                if (null != configEntries || !configEntries.isEmpty()) {
 
                     Map<ConfigResource, Config> updateConfig = new HashMap<ConfigResource, Config>();
                     ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, name);
 
-                    if (retentionMillis == -2) {
+                    Iterator<ConfigEntry> entries = configEntries.iterator();
 
-                        ConfigEntry cleanupPolicy = new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
-                        updateConfig.put(resource, new Config(Collections.singleton(cleanupPolicy)));
-
-                    } else {
-
-                        // create a new entry for updating the retention.ms value on the same topic
-                        ConfigEntry retentionEntry = new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMillis));
-                        updateConfig.put(resource, new Config(Collections.singleton(retentionEntry)));
-
+                    while (entries.hasNext()) {
+                        updateConfig.put(resource, new Config(Collections.singleton(entries.next())));
                     }
 
                     AlterConfigsResult alterConfigsResult = adminClient.alterConfigs(updateConfig);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/KafkaTopicManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/KafkaTopicManager.java
@@ -40,16 +40,24 @@ public class KafkaTopicManager {
 
                 if (retentionMillis != 0) {
 
+                    Map<ConfigResource, Config> updateConfig = new HashMap<ConfigResource, Config>();
                     ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, name);
 
-                    // create a new entry for updating the retention.ms value on the same topic
-                    ConfigEntry retentionEntry = new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMillis));
-                    Map<ConfigResource, Config> updateConfig = new HashMap<ConfigResource, Config>();
-                    updateConfig.put(resource, new Config(Collections.singleton(retentionEntry)));
+                    if (retentionMillis == -2) {
+
+                        ConfigEntry cleanupPolicy = new ConfigEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
+                        updateConfig.put(resource, new Config(Collections.singleton(cleanupPolicy)));
+
+                    } else {
+
+                        // create a new entry for updating the retention.ms value on the same topic
+                        ConfigEntry retentionEntry = new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(retentionMillis));
+                        updateConfig.put(resource, new Config(Collections.singleton(retentionEntry)));
+
+                    }
 
                     AlterConfigsResult alterConfigsResult = adminClient.alterConfigs(updateConfig);
                     alterConfigsResult.all();
-
                 }
             }
         } catch (InterruptedException e) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/SiteStatisticsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/SiteStatisticsStreamsApplication.java
@@ -191,9 +191,6 @@ public class SiteStatisticsStreamsApplication {
                         "localstore_user_data"
                 );
 
-        userData.print();
-
-
         // join user table to incoming event stream to get user data for stats processing
         KStream<String, JsonNode> userEvents = rawStream
                 /*.map(

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/SiteStatisticsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/SiteStatisticsStreamsApplication.java
@@ -35,12 +35,6 @@ import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.kstream.KTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
-import uk.ac.cam.cl.dtg.segue.auth.exceptions.NoUserException;
-import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.users.IUserDataManager;
-import uk.ac.cam.cl.dtg.segue.dto.users.AbstractSegueUserDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import java.sql.Timestamp;
@@ -51,18 +45,21 @@ import java.util.Properties;
  *  @author Dan Underwood
  */
 public class SiteStatisticsStreamsApplication {
-    private static final Logger log = LoggerFactory.getLogger(SiteStatisticsStreamsApplication.class);
+
+    private final Logger log = LoggerFactory.getLogger(SiteStatisticsStreamsApplication.class);
+
+    private static final Serializer<JsonNode> JsonSerializer = new JsonSerializer();
+    private static final Deserializer<JsonNode> JsonDeserializer = new JsonDeserializer();
+    private static final Serde<String> StringSerde = Serdes.String();
+    private static final Serde<JsonNode> JsonSerde = Serdes.serdeFrom(JsonSerializer, JsonDeserializer);
+    private static final Serde<Long> LongSerde = Serdes.Long();
 
     private KafkaTopicManager kafkaTopicManager;
     private KafkaStreams streams;
-    //private static UserAccountManager userManager;
-    static final Serializer<JsonNode> JsonSerializer = new JsonSerializer();
-    static final Deserializer<JsonNode> JsonDeserializer = new JsonDeserializer();
-    static final Serde<String> StringSerde = Serdes.String();
-    static final Serde<JsonNode> JsonSerde = Serdes.serdeFrom(JsonSerializer, JsonDeserializer);
+    private KStreamBuilder builder = new KStreamBuilder();
+    private Properties streamsConfiguration = new Properties();
 
-    protected KStreamBuilder builder = new KStreamBuilder();
-    protected Properties streamsConfiguration = new Properties();
+    private final String streamsAppNameAndVersion = "streamsapp_site_stats-v1.0";
 
 
     /**
@@ -71,17 +68,13 @@ public class SiteStatisticsStreamsApplication {
      *              - properties object containing global variables
      * @param kafkaTopicManager
      *              - manager for kafka topic administration
-     * @param userManager
-     *              - manager for retrieving user details
      */
     public SiteStatisticsStreamsApplication(final PropertiesLoader globalProperties,
                                             final KafkaTopicManager kafkaTopicManager) {
-                                            //final UserAccountManager userManager) {
 
         this.kafkaTopicManager = kafkaTopicManager;
-        //this.userManager = userManager;|
 
-        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "streamsapp_site_stats-v1.0");
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, streamsAppNameAndVersion);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG,
                 globalProperties.getProperty("KAFKA_HOSTNAME") + ":" + globalProperties.getProperty("KAFKA_PORT"));
         streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, globalProperties.getProperty("KAFKA_STREAMS_STATE_DIR"));
@@ -104,6 +97,9 @@ public class SiteStatisticsStreamsApplication {
 
         // ensure topics exist before attempting to consume
         kafkaTopicManager.ensureTopicExists("topic_logged_events_test", -1);
+        kafkaTopicManager.ensureTopicExists(streamsAppNameAndVersion + "-localstore_user_data-changelog", -2);
+        kafkaTopicManager.ensureTopicExists(streamsAppNameAndVersion + "-localstore_user_last_seen-changelog", -2);
+        kafkaTopicManager.ensureTopicExists(streamsAppNameAndVersion + "-localstore_log_event_counts-changelog", -2);
         kafkaTopicManager.ensureTopicExists("topic_anonymous_logged_events_test", 7200000);
 
         // raw logged events incoming data stream from kafka
@@ -113,10 +109,17 @@ public class SiteStatisticsStreamsApplication {
                         (k, v) -> v.path("anonymous_user").asBoolean()
                 );
 
-        // parallel log for anonymous events (may want to optimise how we do this later)
+        // parallel log for anonymous events
         rawLoggedEvents[1].to(StringSerde, JsonSerde, "topic_anonymous_logged_events_test");
 
         streamProcess(rawLoggedEvents[0]);
+
+        // need to make state stores queryable globally, as we often have 2 versions of API running concurrently, hence 2 streams app instances
+        // aggregations are saved to a local state store per streams app instance and update a changelog topic in Kafka
+        // we can use this changelog to populate a global state store for all streams app instances
+        builder.globalTable(StringSerde, JsonSerde,streamsAppNameAndVersion + "-localstore_user_data-changelog", "globalstore_user_data");
+        builder.globalTable(StringSerde, JsonSerde,streamsAppNameAndVersion + "-localstore_user_last_seen-changelog", "globalstore_user_last_seen");
+        builder.globalTable(StringSerde, LongSerde,streamsAppNameAndVersion + "-localstore_log_event_counts-changelog", "globalstore_log_event_counts");
 
         // use the builder and the streams configuration we set to setup and start a streams object
         streams = new KafkaStreams(builder, streamsConfiguration);
@@ -125,7 +128,7 @@ public class SiteStatisticsStreamsApplication {
         // return when streams instance is initialized
         while (true) {
 
-            if (streams.state().isRunning())
+            if (streams.state().isCreatedOrRunning())
                 break;
         }
 
@@ -167,8 +170,10 @@ public class SiteStatisticsStreamsApplication {
                             return userRecord;
                         },
                         JsonSerde,
-                        "store_user_data"
+                        "localstore_user_data"
                 );
+
+        userData.print();
 
 
         // join user table to incoming event stream to get user data for stats processing
@@ -247,7 +252,7 @@ public class SiteStatisticsStreamsApplication {
                             return countRecord;
                         },
                         JsonSerde,
-                        "store_user_last_seen"
+                        "localstore_user_last_seen"
                 );
 
 
@@ -259,7 +264,7 @@ public class SiteStatisticsStreamsApplication {
                         }
                 )
                 .groupByKey(StringSerde, JsonSerde)
-                .count("store_log_event_counts");
+                .count("localstore_log_event_counts");
 
     }
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/database/KafkaStreamsProducer.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/database/KafkaStreamsProducer.java
@@ -66,7 +66,7 @@ public class KafkaStreamsProducer implements Closeable {
         Validate.notBlank(record.key());
 
         if (!topicListCache.contains(record.topic())) {
-            topicManager.ensureTopicExists(record.topic(), 0);
+            topicManager.ensureTopicExists(record.topic(), null);
             topicListCache = topicManager.listTopics();
         }
         producer.send(record);


### PR DESCRIPTION
I believe this fixes the issue: https://github.com/ucam-cl-dtg/isaac-app/issues/891

Introduces a global KTable for access to kafka streams state stores from multiple app instances, so when there are two versions of the API running concurrently then either of them can access state shared across both instances.