### PR TITLE
Feature/maintain fasttrack related question order

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -485,16 +485,20 @@ public class GitContentManager implements IContentManager {
         for (ContentSummaryDTO summary : contentDTO.getRelatedContent()) {
             relatedContentIds.add(summary.getId());
         }
-
         fieldsToMap.put(
                 Maps.immutableEntry(Constants.BooleanOperator.OR, Constants.ID_FIELDNAME + '.'
                         + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX), relatedContentIds);
 
         ResultsWrapper<ContentDTO> results = this.findByFieldNames(version, fieldsToMap, 0, relatedContentIds.size());
-
         List<ContentSummaryDTO> relatedContentDTOs = Lists.newArrayList();
 
+        Map<String, ContentDTO> resultsMappedByIds = Maps.newHashMap();
         for (ContentDTO relatedContent : results.getResults()) {
+            resultsMappedByIds.put(relatedContent.getId(), relatedContent);
+        }
+        // Iterate over relatedContentIds so that relatedContentDTOs maintain order defined in content not result order
+        for (String contentId : relatedContentIds) {
+            ContentDTO relatedContent = resultsMappedByIds.get(contentId);
             ContentSummaryDTO summary = this.mapper.getAutoMapper().map(relatedContent, ContentSummaryDTO.class);
             GitContentManager.generateDerivedSummaryValues(relatedContent, summary);
             relatedContentDTOs.add(summary);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -485,20 +485,22 @@ public class GitContentManager implements IContentManager {
         for (ContentSummaryDTO summary : contentDTO.getRelatedContent()) {
             relatedContentIds.add(summary.getId());
         }
+
         fieldsToMap.put(
                 Maps.immutableEntry(Constants.BooleanOperator.OR, Constants.ID_FIELDNAME + '.'
                         + Constants.UNPROCESSED_SEARCH_FIELD_SUFFIX), relatedContentIds);
 
         ResultsWrapper<ContentDTO> results = this.findByFieldNames(version, fieldsToMap, 0, relatedContentIds.size());
+
         List<ContentSummaryDTO> relatedContentDTOs = Lists.newArrayList();
 
-        Map<String, ContentDTO> resultsMappedByIds = Maps.newHashMap();
+        Map<String, ContentDTO> resultsMappedById = Maps.newHashMap();
         for (ContentDTO relatedContent : results.getResults()) {
-            resultsMappedByIds.put(relatedContent.getId(), relatedContent);
+            resultsMappedById.put(relatedContent.getId(), relatedContent);
         }
         // Iterate over relatedContentIds so that relatedContentDTOs maintain order defined in content not result order
         for (String contentId : relatedContentIds) {
-            ContentDTO relatedContent = resultsMappedByIds.get(contentId);
+            ContentDTO relatedContent = resultsMappedById.get(contentId);
             ContentSummaryDTO summary = this.mapper.getAutoMapper().map(relatedContent, ContentSummaryDTO.class);
             GitContentManager.generateDerivedSummaryValues(relatedContent, summary);
             relatedContentDTOs.add(summary);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/content/GitContentManager.java
@@ -501,9 +501,13 @@ public class GitContentManager implements IContentManager {
         // Iterate over relatedContentIds so that relatedContentDTOs maintain order defined in content not result order
         for (String contentId : relatedContentIds) {
             ContentDTO relatedContent = resultsMappedById.get(contentId);
-            ContentSummaryDTO summary = this.mapper.getAutoMapper().map(relatedContent, ContentSummaryDTO.class);
-            GitContentManager.generateDerivedSummaryValues(relatedContent, summary);
-            relatedContentDTOs.add(summary);
+            if (relatedContent != null) {
+                ContentSummaryDTO summary = this.mapper.getAutoMapper().map(relatedContent, ContentSummaryDTO.class);
+                GitContentManager.generateDerivedSummaryValues(relatedContent, summary);
+                relatedContentDTOs.add(summary);
+            } else {
+                log.error("Related content with ID '" + contentId + "' not returned by elasticsearch query");
+            }
         }
 
         contentDTO.setRelatedContent(relatedContentDTOs);


### PR DESCRIPTION
Alter code so that related content maintains order defined in content not the order given by the Elasticsearch query result.