### PR TITLE
Set Kafka logged events topic name as a global variable

### DIFF
--- a/config-templates/linux-local-dev-segue-config.properties
+++ b/config-templates/linux-local-dev-segue-config.properties
@@ -45,6 +45,7 @@ POSTGRES_DB_PASSWORD=rutherf0rd
 KAFKA_HOSTNAME=localhost
 KAFKA_PORT=9092
 KAFKA_REPLICATION_FACTOR=1
+KAFKA_TOPIC_LOGGED_EVENTS=topic_logged_events_v1
 
 # Kafka Streams Applications
 KAFKA_STREAMS_STATE_DIR=/tmp/kafka-streams-state

--- a/config-templates/windows--local-dev-segue-config.properties
+++ b/config-templates/windows--local-dev-segue-config.properties
@@ -45,6 +45,7 @@ POSTGRES_DB_PASSWORD=rutherf0rd
 KAFKA_HOSTNAME=localhost
 KAFKA_PORT=9092
 KAFKA_REPLICATION_FACTOR=1
+KAFKA_TOPIC_LOGGED_EVENTS=topic_logged_events_v1
 
 # Kafka Streams Applications
 KAFKA_STREAMS_STATE_DIR=C:\\tmp\\kafka-streams-state

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -220,7 +220,7 @@ public final class Constants {
     // Kafka Properties
     public static final String KAFKA_HOSTNAME = "KAFKA_HOSTNAME";
     public static final String KAFKA_PORT = "KAFKA_PORT";
-    public static final String KAFKA_TOPIC_LOGGED_EVENTS = "KAFKA_TOPIC_LOGGED_EVENTS";
+    public static final String KAFKA_TOPIC_LOGGED_EVENTS = "topic_logged_events_v1";
 
     // Logging component
     public static final String LOGGING_ENABLED = "LOGGING_ENABLED";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -220,6 +220,7 @@ public final class Constants {
     // Kafka Properties
     public static final String KAFKA_HOSTNAME = "KAFKA_HOSTNAME";
     public static final String KAFKA_PORT = "KAFKA_PORT";
+    public static final String KAFKA_TOPIC_LOGGED_EVENTS = "KAFKA_TOPIC_LOGGED_EVENTS";
 
     // Logging component
     public static final String LOGGING_ENABLED = "LOGGING_ENABLED";

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -190,7 +190,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
         // Kafka
         this.bindConstantToProperty(Constants.KAFKA_HOSTNAME, globalProperties);
         this.bindConstantToProperty(Constants.KAFKA_PORT, globalProperties);
-        this.bindConstantToProperty(Constants.KAFKA_TOPIC_LOGGED_EVENTS, globalProperties);
 
         // GitDb
         bind(GitDb.class).toInstance(
@@ -362,7 +361,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
                                              @Named(Constants.LOGGING_ENABLED) final boolean loggingEnabled, final LocationManager lhm,
                                              @Named(Constants.KAFKA_HOSTNAME) final String kafkaHost,
                                              @Named(Constants.KAFKA_PORT) final String kafkaPort,
-                                             @Named(Constants.KAFKA_TOPIC_LOGGED_EVENTS) final String kafkaTopic,
                                              final KafkaStreamsProducer kafkaProducer) {
 
         if (null == logManager) {
@@ -373,7 +371,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
             //logManager = new PgLogManager(database, objectMapper, loggingEnabled, lhm);
 
             logManager = new PgLogManagerEventListener(new PgLogManager(database, objectMapper, loggingEnabled, lhm));
-            logManager.addListener(new KafkaLoggingManager(kafkaProducer, lhm, objectMapper, kafkaHost, kafkaPort, kafkaTopic, kafkaTopicManager));
+            logManager.addListener(new KafkaLoggingManager(kafkaProducer, lhm, objectMapper, kafkaHost, kafkaPort, kafkaTopicManager));
 
             log.info("Creating singleton of LogManager");
             if (loggingEnabled) {
@@ -699,7 +697,6 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Inject
     private static KafkaStreamsProducer getKafkaProducer(@Named(Constants.KAFKA_HOSTNAME) final String kafkaHost,
                                                          @Named(Constants.KAFKA_PORT) final String kafkaPort,
-                                                         @Named(Constants.KAFKA_TOPIC_LOGGED_EVENTS) final String kafkaTopic,
                                                          final KafkaTopicManager topicManager) {
 
         if (null == kafkaProducer) {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/configuration/SegueGuiceConfigurationModule.java
@@ -190,6 +190,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
         // Kafka
         this.bindConstantToProperty(Constants.KAFKA_HOSTNAME, globalProperties);
         this.bindConstantToProperty(Constants.KAFKA_PORT, globalProperties);
+        this.bindConstantToProperty(Constants.KAFKA_TOPIC_LOGGED_EVENTS, globalProperties);
 
         // GitDb
         bind(GitDb.class).toInstance(
@@ -361,6 +362,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
                                              @Named(Constants.LOGGING_ENABLED) final boolean loggingEnabled, final LocationManager lhm,
                                              @Named(Constants.KAFKA_HOSTNAME) final String kafkaHost,
                                              @Named(Constants.KAFKA_PORT) final String kafkaPort,
+                                             @Named(Constants.KAFKA_TOPIC_LOGGED_EVENTS) final String kafkaTopic,
                                              final KafkaStreamsProducer kafkaProducer) {
 
         if (null == logManager) {
@@ -371,7 +373,7 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
             //logManager = new PgLogManager(database, objectMapper, loggingEnabled, lhm);
 
             logManager = new PgLogManagerEventListener(new PgLogManager(database, objectMapper, loggingEnabled, lhm));
-            logManager.addListener(new KafkaLoggingManager(kafkaProducer, lhm, objectMapper, kafkaHost, kafkaPort, kafkaTopicManager));
+            logManager.addListener(new KafkaLoggingManager(kafkaProducer, lhm, objectMapper, kafkaHost, kafkaPort, kafkaTopic, kafkaTopicManager));
 
             log.info("Creating singleton of LogManager");
             if (loggingEnabled) {
@@ -696,8 +698,9 @@ public class SegueGuiceConfigurationModule extends AbstractModule implements Ser
     @Singleton
     @Inject
     private static KafkaStreamsProducer getKafkaProducer(@Named(Constants.KAFKA_HOSTNAME) final String kafkaHost,
-                                         @Named(Constants.KAFKA_PORT) final String kafkaPort,
-                                         final KafkaTopicManager topicManager) {
+                                                         @Named(Constants.KAFKA_PORT) final String kafkaPort,
+                                                         @Named(Constants.KAFKA_TOPIC_LOGGED_EVENTS) final String kafkaTopic,
+                                                         final KafkaTopicManager topicManager) {
 
         if (null == kafkaProducer) {
             kafkaProducer = new KafkaStreamsProducer(kafkaHost, kafkaPort, topicManager);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
@@ -73,7 +73,6 @@ public class KafkaLoggingManager extends LoggingEventHandler {
     private final ObjectMapper objectMapper;
     private final String kafkaHost;
     private final String kafkaPort;
-    private final String kafkaTopic;
 
 
     @Inject
@@ -82,7 +81,6 @@ public class KafkaLoggingManager extends LoggingEventHandler {
                                final ObjectMapper objectMapper,
                                @Named(Constants.KAFKA_HOSTNAME) final String kafkaHost,
                                @Named(Constants.KAFKA_PORT) final String kafkaPort,
-                               @Named(Constants.KAFKA_TOPIC_LOGGED_EVENTS) final String kafkaTopic,
                                KafkaTopicManager kafkaTopicManager) {
 
         this.kafkaProducer = kafkaProducer;
@@ -90,13 +88,12 @@ public class KafkaLoggingManager extends LoggingEventHandler {
         this.objectMapper = objectMapper;
         this.kafkaHost = kafkaHost;
         this.kafkaPort = kafkaPort;
-        this.kafkaTopic = kafkaTopic;
 
         // ensure topics exist before attempting to consume
         // logged events
         List<ConfigEntry> loggedEventsConfigs = Lists.newLinkedList();
         loggedEventsConfigs.add(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(-1)));
-        kafkaTopicManager.ensureTopicExists(kafkaTopic, loggedEventsConfigs);
+        kafkaTopicManager.ensureTopicExists(Constants.KAFKA_TOPIC_LOGGED_EVENTS, loggedEventsConfigs);
 
         // anonymous logged events
         List<ConfigEntry> anonLoggedEventsConfigs = Lists.newLinkedList();
@@ -176,7 +173,7 @@ public class KafkaLoggingManager extends LoggingEventHandler {
                                 .build();
 
                         // producerRecord contains the name of the kafka topic we are publishing to, followed by the message to be sent.
-                        ProducerRecord<String, String> producerRecord = new ProducerRecord<String, String>(kafkaTopic, newUserId,
+                        ProducerRecord<String, String> producerRecord = new ProducerRecord<String, String>(Constants.KAFKA_TOPIC_LOGGED_EVENTS, newUserId,
                                 objectMapper.writeValueAsString(kafkaLogRecord));
 
                         kafkaProducer.send(producerRecord);
@@ -229,7 +226,7 @@ public class KafkaLoggingManager extends LoggingEventHandler {
                 .build();
 
         // producerRecord contains the name of the kafka topic we are publishing to, followed by the message to be sent.
-        ProducerRecord producerRecord = new ProducerRecord<String, String>(kafkaTopic, logEvent.getUserId(),
+        ProducerRecord producerRecord = new ProducerRecord<String, String>(Constants.KAFKA_TOPIC_LOGGED_EVENTS, logEvent.getUserId(),
                 objectMapper.writeValueAsString(kafkaLogRecord));
 
         try {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/KafkaLoggingManager.java
@@ -73,6 +73,7 @@ public class KafkaLoggingManager extends LoggingEventHandler {
     private final ObjectMapper objectMapper;
     private final String kafkaHost;
     private final String kafkaPort;
+    private final String kafkaTopic;
 
 
     @Inject
@@ -81,6 +82,7 @@ public class KafkaLoggingManager extends LoggingEventHandler {
                                final ObjectMapper objectMapper,
                                @Named(Constants.KAFKA_HOSTNAME) final String kafkaHost,
                                @Named(Constants.KAFKA_PORT) final String kafkaPort,
+                               @Named(Constants.KAFKA_TOPIC_LOGGED_EVENTS) final String kafkaTopic,
                                KafkaTopicManager kafkaTopicManager) {
 
         this.kafkaProducer = kafkaProducer;
@@ -88,12 +90,13 @@ public class KafkaLoggingManager extends LoggingEventHandler {
         this.objectMapper = objectMapper;
         this.kafkaHost = kafkaHost;
         this.kafkaPort = kafkaPort;
+        this.kafkaTopic = kafkaTopic;
 
         // ensure topics exist before attempting to consume
         // logged events
         List<ConfigEntry> loggedEventsConfigs = Lists.newLinkedList();
         loggedEventsConfigs.add(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(-1)));
-        kafkaTopicManager.ensureTopicExists("topic_logged_events_v1", loggedEventsConfigs);
+        kafkaTopicManager.ensureTopicExists(kafkaTopic, loggedEventsConfigs);
 
         // anonymous logged events
         List<ConfigEntry> anonLoggedEventsConfigs = Lists.newLinkedList();
@@ -173,7 +176,7 @@ public class KafkaLoggingManager extends LoggingEventHandler {
                                 .build();
 
                         // producerRecord contains the name of the kafka topic we are publishing to, followed by the message to be sent.
-                        ProducerRecord<String, String> producerRecord = new ProducerRecord<String, String>("topic_logged_events_v1", newUserId,
+                        ProducerRecord<String, String> producerRecord = new ProducerRecord<String, String>(kafkaTopic, newUserId,
                                 objectMapper.writeValueAsString(kafkaLogRecord));
 
                         kafkaProducer.send(producerRecord);
@@ -226,7 +229,7 @@ public class KafkaLoggingManager extends LoggingEventHandler {
                 .build();
 
         // producerRecord contains the name of the kafka topic we are publishing to, followed by the message to be sent.
-        ProducerRecord producerRecord = new ProducerRecord<String, String>("topic_logged_events_v1", logEvent.getUserId(),
+        ProducerRecord producerRecord = new ProducerRecord<String, String>(kafkaTopic, logEvent.getUserId(),
                 objectMapper.writeValueAsString(kafkaLogRecord));
 
         try {

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/AnonymousEventsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/AnonymousEventsStreamsApplication.java
@@ -15,6 +15,7 @@ import org.apache.kafka.connect.json.JsonSerializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import java.util.List;
@@ -35,7 +36,6 @@ public class AnonymousEventsStreamsApplication {
     public AnonymousEventsStreamsApplication(final PropertiesLoader globalProperties,
                                             final KafkaTopicManager kafkaTopicManager) {
 
-        String kafkaTopic = globalProperties.getProperty("KAFKA_TOPIC_LOGGED_EVENTS");
         KStreamBuilder builder = new KStreamBuilder();
         Properties streamsConfiguration = new Properties();
 
@@ -58,7 +58,7 @@ public class AnonymousEventsStreamsApplication {
         // logged events
         List<ConfigEntry> loggedEventsConfigs = Lists.newLinkedList();
         loggedEventsConfigs.add(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(-1)));
-        kafkaTopicManager.ensureTopicExists(kafkaTopic, loggedEventsConfigs);
+        kafkaTopicManager.ensureTopicExists(Constants.KAFKA_TOPIC_LOGGED_EVENTS, loggedEventsConfigs);
 
         // anonymous logged events
         List<ConfigEntry> anonLoggedEventsConfigs = Lists.newLinkedList();
@@ -67,7 +67,7 @@ public class AnonymousEventsStreamsApplication {
 
 
         // raw logged events incoming data stream from kafka
-        builder.stream(StringSerde, JsonSerde, kafkaTopic)
+        builder.stream(StringSerde, JsonSerde, Constants.KAFKA_TOPIC_LOGGED_EVENTS)
                 .filter(
                         (k, v) -> v.path("anonymous_user").asBoolean()
                 ).to(StringSerde, JsonSerde, "topic_anonymous_logged_events");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/AnonymousEventsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/AnonymousEventsStreamsApplication.java
@@ -35,6 +35,7 @@ public class AnonymousEventsStreamsApplication {
     public AnonymousEventsStreamsApplication(final PropertiesLoader globalProperties,
                                             final KafkaTopicManager kafkaTopicManager) {
 
+        String kafkaTopic = globalProperties.getProperty("KAFKA_TOPIC_LOGGED_EVENTS");
         KStreamBuilder builder = new KStreamBuilder();
         Properties streamsConfiguration = new Properties();
 
@@ -57,7 +58,7 @@ public class AnonymousEventsStreamsApplication {
         // logged events
         List<ConfigEntry> loggedEventsConfigs = Lists.newLinkedList();
         loggedEventsConfigs.add(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(-1)));
-        kafkaTopicManager.ensureTopicExists("topic_logged_events_v1", loggedEventsConfigs);
+        kafkaTopicManager.ensureTopicExists(kafkaTopic, loggedEventsConfigs);
 
         // anonymous logged events
         List<ConfigEntry> anonLoggedEventsConfigs = Lists.newLinkedList();
@@ -66,7 +67,7 @@ public class AnonymousEventsStreamsApplication {
 
 
         // raw logged events incoming data stream from kafka
-        builder.stream(StringSerde, JsonSerde, "topic_logged_events_v1")
+        builder.stream(StringSerde, JsonSerde, kafkaTopic)
                 .filter(
                         (k, v) -> v.path("anonymous_user").asBoolean()
                 ).to(StringSerde, JsonSerde, "topic_anonymous_logged_events");

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.api.managers.UserAccountManager;
 import uk.ac.cam.cl.dtg.segue.api.userAlerts.IAlertListener;
 import uk.ac.cam.cl.dtg.segue.api.userAlerts.UserAlertsWebSocket;
@@ -87,7 +88,6 @@ public class UserStatisticsStreamsApplication {
     private IQuestionAttemptManager questionAttemptManager;
     private UserAccountManager userAccountManager;
     private ILogManager logManager;
-    private String kafkaTopic;
 
 
     private final String streamsAppNameAndVersion = "streamsapp_user_stats-v1.0";
@@ -111,7 +111,6 @@ public class UserStatisticsStreamsApplication {
         this.questionAttemptManager = questionAttemptManager;
         this.userAccountManager = userAccountManager;
         this.logManager = logManager;
-        this.kafkaTopic = globalProperties.getProperty("KAFKA_TOPIC_LOGGED_EVENTS");
 
 
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, streamsAppNameAndVersion);
@@ -141,7 +140,7 @@ public class UserStatisticsStreamsApplication {
         // logged events
         List<ConfigEntry> loggedEventsConfigs = Lists.newLinkedList();
         loggedEventsConfigs.add(new ConfigEntry(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(-1)));
-        kafkaTopicManager.ensureTopicExists(kafkaTopic, loggedEventsConfigs);
+        kafkaTopicManager.ensureTopicExists(Constants.KAFKA_TOPIC_LOGGED_EVENTS, loggedEventsConfigs);
 
         // local store changelog topics
         List<ConfigEntry> changelogConfigs = Lists.newLinkedList();
@@ -152,7 +151,7 @@ public class UserStatisticsStreamsApplication {
         final AtomicBoolean wasLagging = new AtomicBoolean(true);
 
         // raw logged events incoming data stream from kafka
-        KStream<String, JsonNode> rawLoggedEvents = builder.stream(StringSerde, JsonSerde, kafkaTopic)
+        KStream<String, JsonNode> rawLoggedEvents = builder.stream(StringSerde, JsonSerde, Constants.KAFKA_TOPIC_LOGGED_EVENTS)
                 .filterNot(
                         (k, v) -> v.path("anonymous_user").asBoolean()
                 ).peek(

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/KafkaUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/KafkaUsers.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
+import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.auth.AuthenticationProvider;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.database.KafkaStreamsProducer;
@@ -25,7 +26,6 @@ public class KafkaUsers implements IUserDataManager {
 
     private PgUsers pgUsers;
     private KafkaStreamsProducer kafkaProducer;
-    private String kafkaTopic;
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -36,7 +36,6 @@ public class KafkaUsers implements IUserDataManager {
 
         this.pgUsers = new PgUsers(postgresSqlDb);
         this.kafkaProducer = kafkaProducer;
-        this.kafkaTopic = globalProperties.getProperty("KAFKA_TOPIC_LOGGED_EVENTS");
 
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
@@ -60,7 +59,7 @@ public class KafkaUsers implements IUserDataManager {
                 .build();
         try {
             // producerRecord contains the name of the kafka topic we are publishing to, followed by the message to be sent.
-            ProducerRecord producerRecord = new ProducerRecord<String, String>(kafkaTopic, regUser.getId().toString(),
+            ProducerRecord producerRecord = new ProducerRecord<String, String>(Constants.KAFKA_TOPIC_LOGGED_EVENTS, regUser.getId().toString(),
                     objectMapper.writeValueAsString(kafkaLogRecord));
 
             kafkaProducer.send(producerRecord);


### PR DESCRIPTION
Removes the need to change the string across the API whenever the logged events topic name changes (even though this should happen rarely).

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ n/a] Added enough Logging to monitor expected behaviour change
- [x] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
- [n/a] Security - Access Control - Check authorisation on every new endpoint
- [n/a] Security - New dependency - configured sensibly not relying on defaults
- [n/a] Security - New dependency - Searched for any know vulnerabilities
- [n/a] Security - New dependency - Signed up team to mailing list
- [n/a] Security - New dependency - Added to dependency list
- [n/a] DB schema changes - postgres-rutherford-create-script updated
- [n/a] DB schema changes - upgrade script created matching create script
- [n/a] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed

Signed Off By: @