### PR TITLE
Handling thrown exceptions in kafka streams app

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/userAlerts/UserAlertsWebSocket.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/userAlerts/UserAlertsWebSocket.java
@@ -132,12 +132,7 @@ public class UserAlertsWebSocket implements IAlertListener {
                 // TODO: Send initial set of notifications.
                 List<IUserAlert> persistedAlerts = userAlerts.getUserAlerts(connectedUser.getId());
                 if (!persistedAlerts.isEmpty()) {
-
-                    try {
-                        session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("notifications", persistedAlerts)));
-                    } catch (IllegalStateException e) {
-                        e.printStackTrace();
-                    }
+                    session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("notifications", persistedAlerts)));
                 }
 
                 websocketsOpened++;
@@ -201,7 +196,7 @@ public class UserAlertsWebSocket implements IAlertListener {
     public void notifyAlert(final IUserAlert alert) {
         try {
             this.session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("notifications", ImmutableList.of(alert))));
-        } catch (IOException | IllegalStateException e) {
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }
@@ -215,12 +210,8 @@ public class UserAlertsWebSocket implements IAlertListener {
      */
     private void sendUserSnapshotData() throws IOException {
 
-        try {
-            session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("userSnapshot",
-                    userStatisticsStreamsApplication.getUserSnapshot(connectedUser))));
-        } catch (IllegalStateException e) {
-            e.printStackTrace();
-        }
+        session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("userSnapshot",
+                userStatisticsStreamsApplication.getUserSnapshot(connectedUser))));
     }
 
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/userAlerts/UserAlertsWebSocket.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/userAlerts/UserAlertsWebSocket.java
@@ -132,7 +132,12 @@ public class UserAlertsWebSocket implements IAlertListener {
                 // TODO: Send initial set of notifications.
                 List<IUserAlert> persistedAlerts = userAlerts.getUserAlerts(connectedUser.getId());
                 if (!persistedAlerts.isEmpty()) {
-                    session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("notifications", persistedAlerts)));
+
+                    try {
+                        session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("notifications", persistedAlerts)));
+                    } catch (IllegalStateException e) {
+                        e.printStackTrace();
+                    }
                 }
 
                 websocketsOpened++;
@@ -196,7 +201,7 @@ public class UserAlertsWebSocket implements IAlertListener {
     public void notifyAlert(final IUserAlert alert) {
         try {
             this.session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("notifications", ImmutableList.of(alert))));
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException e) {
             e.printStackTrace();
         }
     }
@@ -210,8 +215,12 @@ public class UserAlertsWebSocket implements IAlertListener {
      */
     private void sendUserSnapshotData() throws IOException {
 
-        session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("userSnapshot",
-                userStatisticsStreamsApplication.getUserSnapshot(connectedUser))));
+        try {
+            session.getRemote().sendString(objectMapper.writeValueAsString(ImmutableMap.of("userSnapshot",
+                    userStatisticsStreamsApplication.getUserSnapshot(connectedUser))));
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+        }
     }
 
 

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/SiteStatisticsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/SiteStatisticsStreamsApplication.java
@@ -215,11 +215,11 @@ public class SiteStatisticsStreamsApplication {
                         // aggregator
                         (userId, userUpdateLogEvent, userRecord) -> {
 
-                            String eventType = userUpdateLogEvent.path("event_type").asText();
+                            try {
 
-                            if (eventType.equals("CREATE_UPDATE_USER")) {
+                                String eventType = userUpdateLogEvent.path("event_type").asText();
 
-                                try {
+                                if (eventType.equals("CREATE_UPDATE_USER")) {
 
                                     // we get the latest record from postgres to avoid passing sensitive info through Kafka
                                     RegisteredUserDTO regUser = userAccountManager.getUserDTOById(Long.parseLong(userId));
@@ -237,40 +237,44 @@ public class SiteStatisticsStreamsApplication {
 
                                     ((ObjectNode) userRecord).put("user_id", userId);
                                     ((ObjectNode) userRecord).set("user_data", userDetails);
+                                }
 
-                                } catch (SegueDatabaseException e) {
-                                    e.printStackTrace();
-                                } catch (NoUserException e) {
+                                // record user last seen data
+                                JsonNode lastSeenData = userRecord.path("last_seen_data");
+                                Timestamp stamp = new Timestamp(userUpdateLogEvent.path("timestamp").asLong());
+
+
+                                if (!lastSeenData.has(eventType)) {
+                                    ObjectNode node = JsonNodeFactory.instance.objectNode();
+                                    node.put("count", 0);
+                                    node.put("latest", 0);
+                                    ((ObjectNode) lastSeenData).set(eventType, node);
+                                }
+
+                                Long count = lastSeenData.path(eventType).path("count").asLong();
+                                ((ObjectNode) lastSeenData.path(eventType)).put("count", count + 1);
+                                ((ObjectNode) lastSeenData.path(eventType)).put("latest", stamp.getTime());
+                                ((ObjectNode) lastSeenData).put("last_seen", stamp.getTime());
+
+                            } catch (Exception e) {
+                                // streams app annoyingly dies if there is an uncaught exception from any level, so we catch everything
+                                if (e instanceof NoUserException) {
                                     // don't want to clog up the logs with historical processing if we are ever doing a backfill
                                     if (userUpdateLogEvent.path("timestamp").asLong() > streamAppStartTime) {
                                         log.error("User " + userId + " not found in Postgres DB while processing streams data!");
                                     }
                                     // returning a null record will ensure that it will be removed from the internal rocksDB store
                                     return null;
-                                } catch (NumberFormatException e) {
+
+                                } else if (e instanceof NumberFormatException) {
                                     if (userUpdateLogEvent.path("timestamp").asLong() > streamAppStartTime) {
                                         log.error("Could not process user with id = " + userId + " in streams application.");
                                     }
                                     return null;
+                                } else {
+                                    e.printStackTrace();
                                 }
                             }
-
-                            // record user last seen data
-                            JsonNode lastSeenData = userRecord.path("last_seen_data");
-                            Timestamp stamp = new Timestamp(userUpdateLogEvent.path("timestamp").asLong());
-
-
-                            if (!lastSeenData.has(eventType)) {
-                                ObjectNode node = JsonNodeFactory.instance.objectNode();
-                                node.put("count", 0);
-                                node.put("latest", 0);
-                                ((ObjectNode) lastSeenData).set(eventType, node);
-                            }
-
-                            Long count = lastSeenData.path(eventType).path("count").asLong();
-                            ((ObjectNode) lastSeenData.path(eventType)).put("count", count + 1);
-                            ((ObjectNode) lastSeenData.path(eventType)).put("latest", stamp.getTime());
-                            ((ObjectNode) lastSeenData).put("last_seen", stamp.getTime());
 
                             return userRecord;
                         },

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
@@ -260,15 +260,13 @@ public class UserStatisticsStreamsApplication {
 
                                 }
 
-                            } catch (Exception e) {
-                                // streams app annoyingly dies if there is an uncaught exception from any level, so we catch everything
-                                if (e instanceof NoUserException) {
-                                    log.error("User " + userId + " not found in Postgres DB while processing streams data!");
-                                } else if (e instanceof NumberFormatException) {
-                                    log.error("Could not process user with id = " + userId + " in streams application.");
-                                } else {
-                                    e.printStackTrace();
-                                }
+                            } catch (NoUserException e) {
+                                log.error("User " + userId + " not found in Postgres DB while processing streams data!");
+                            } catch (NumberFormatException | SegueDatabaseException e) {
+                                log.error("Could not process user with id = " + userId + " in streams application.");
+                            } catch (RuntimeException e) {
+                                // streams app annoyingly dies if there is an uncaught runtime exception from any level, so we catch everything
+                                e.printStackTrace();
                             }
 
                             return userSnapshot;

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
@@ -218,7 +218,7 @@ public class UserStatisticsStreamsApplication {
                             streakRecord.put("current_activity", 0);
                             streakRecord.put("activity_threshold", 3);
 
-                            userSnapshot.put("streak_record", streakRecord);
+                            userSnapshot.set("streak_record", streakRecord);
 
                             return userSnapshot;
                         },
@@ -233,37 +233,43 @@ public class UserStatisticsStreamsApplication {
                                 teacherRecord.put("assignments_set", 0);
                                 teacherRecord.put("book_pages_set", 0);
                                 teacherRecord.put("cpd_events_attended", 0);
-                                ((ObjectNode) userSnapshot).put("teacher_record", teacherRecord);
+                                ((ObjectNode) userSnapshot).set("teacher_record", teacherRecord);
                             }
 
 
-                            // snapshot updates pertaining to question answer activity
-                            if (latestEvent.path("event_type").asText().equals("ANSWER_QUESTION")) {
-
-                                if (latestEvent.path("event_details").path("correct").asBoolean()) {
-                                    ((ObjectNode) userSnapshot).put("streak_record", updateStreakRecord(userId, latestEvent, userSnapshot.path("streak_record")));
-                                }
-                            }
-
-                            // snapshot updates pertaining to teacher activity
                             try {
 
+                                // snapshot updates pertaining to question answer activity
+                                if (latestEvent.path("event_type").asText().equals("ANSWER_QUESTION")) {
+
+                                    if (latestEvent.path("event_details").path("correct").asBoolean()) {
+                                        ((ObjectNode) userSnapshot).set("streak_record", updateStreakRecord(userId, latestEvent, userSnapshot.path("streak_record")));
+                                    }
+                                }
+
+                                // snapshot updates pertaining to teacher activity
                                 if (!userAccountManager.getUserDTOById(Long.parseLong(userId)).getRole().equals(Role.STUDENT)) {
 
                                     if (latestEvent.path("event_type").asText().equals("CREATE_USER_GROUP")) {
-                                        ((ObjectNode) userSnapshot).put("teacher_record", updateTeacherActivityRecord("groups_created", userSnapshot.path("teacher_record")));
+                                        ((ObjectNode) userSnapshot).set("teacher_record", updateTeacherActivityRecord("groups_created", userSnapshot.path("teacher_record")));
                                     }
 
                                     if (latestEvent.path("event_type").asText().equals("SET_NEW_ASSIGNMENT")) {
-                                        ((ObjectNode) userSnapshot).put("teacher_record", updateTeacherActivityRecord("assignments_set", userSnapshot.path("teacher_record")));
+                                        ((ObjectNode) userSnapshot).set("teacher_record", updateTeacherActivityRecord("assignments_set", userSnapshot.path("teacher_record")));
                                     }
 
                                 }
 
-                            } catch (NoUserException | SegueDatabaseException e) {
-                                e.printStackTrace();
+                            } catch (Exception e) {
+                                // streams app annoyingly dies if there is an uncaught exception from any level, so we catch everything
+                                if (e instanceof NoUserException) {
+                                    log.error("User " + userId + " not found in Postgres DB while processing streams data!");
+                                } else if (e instanceof NumberFormatException) {
+                                    log.error("Could not process user with id = " + userId + " in streams application.");
+                                } else {
+                                    e.printStackTrace();
+                                }
                             }
-
 
                             return userSnapshot;
                         },


### PR DESCRIPTION
This is an uber quickfix which prevents an exception in websockets form crashing the streamsapp.

The streams app crashing in itself is an issue that we need to address so we might not end up using this...

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
