### PR TITLE
Fix fields missing from event DTO required for new templates

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/managers/EventBookingManager.java
@@ -433,7 +433,6 @@ public class EventBookingManager {
                         emailManager.getEmailTemplateDTO("email-event-waiting-list-addition-notification"),
                         new ImmutableMap.Builder<String, Object>()
                                 .put("contactUsURL", generateEventContactUsURL(event))
-                                .put("event.emailEventDetails", event.getEmailEventDetails() == null ? "" : event.getEmailEventDetails())
                                 .put("event", event)
                                 .build(),
                         EmailType.SYSTEM);

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dto/IsaacEventPageDTO.java
@@ -48,6 +48,8 @@ public class IsaacEventPageDTO extends ContentDTO {
     private List<ExternalReference> preResources;
     private List<ContentDTO> preResourceContent;
     private String emailEventDetails;
+    private String emailConfirmedBookingText;
+    private String emailWaitingListBookingText;
 
     private List<ExternalReference> postResources;
     private List<ContentDTO> postResourceContent;
@@ -447,12 +449,57 @@ public class IsaacEventPageDTO extends ContentDTO {
         isUserOnWaitList = userOnWaitList;
     }
 
+    /**
+     * Get information about the event that is common to all booking system emails
+     * @return emailEventDetails
+     */
     @JsonIgnore
     public String getEmailEventDetails() {
         return emailEventDetails;
     }
 
+    /**
+     * Set the email event details.
+     * @param emailEventDetails - the text to show in the email token
+     */
     public void setEmailEventDetails(final String emailEventDetails) {
         this.emailEventDetails = emailEventDetails;
+    }
+
+
+    /**
+     * Get text about the event for the confirmed emails
+     *
+     * @return emailEventDetails
+     */
+    @JsonIgnore
+    public String getEmailConfirmedBookingText() {
+        return emailConfirmedBookingText;
+    }
+
+    /**
+     * Set the email confirmed booking text for emails.
+     * @param emailConfirmedBookingText - text to show in emails
+     */
+    public void setEmailConfirmedBookingText(String emailConfirmedBookingText) {
+        this.emailConfirmedBookingText = emailConfirmedBookingText;
+    }
+
+    /**
+     * Get text about the event for the waiting list emails
+     *
+     * @return emailEventDetails
+     */
+    @JsonIgnore
+    public String getEmailWaitingListBookingText() {
+        return emailWaitingListBookingText;
+    }
+
+    /**
+     * Set the email waiting list text for emails.
+     * @param emailWaitingListBookingText - text to show in email.
+     */
+    public void setEmailWaitingListBookingText(String emailWaitingListBookingText) {
+        this.emailWaitingListBookingText = emailWaitingListBookingText;
     }
 }


### PR DESCRIPTION
In order to send the new information in the emails, the fields need to be on the DTO as well as the DO!
We can safely remove the `event.emailEventDetails` key because it will be generated by flattening the `event` object anyway!

If you want to test this, you will need the new template with the new properties found on the `event-emails` branch of the content. Change lines 368 and 394 of [`GitDb.java`](https://github.com/ucam-cl-dtg/isaac-api/blob/215bb59ef71f40d3d12a4d56c6d4ba46f6e08e7c/src/main/java/uk/ac/cam/cl/dtg/segue/database/GitDb.java) to refer to `origin/event-emails` rather than `origin/master`, re-run ETL and then test. The event `29082018cambridge` uses the new waiting-list-only properties and has the new email fields, and the event `21032018carterton` does not (for comparison).

---

**Pull Request Check List**
- Unit Tests & Regression Tests Added (Optional)
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- Added enough Logging to monitor expected behaviour change
- Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- Security - Data Exposure - PII is not stored or sent unencrypted
- Security - Access Control - Check authorisation on every new endpoint
- DB schema changes - postgres-rutherford-create-script updated
- DB schema changes - upgrade script created matching create script
- Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
