### PR TITLE
New endpoint to get all users' streaks

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -1665,4 +1665,28 @@ public class AdminFacade extends AbstractSegueFacade {
         }
     }
 
+
+    @GET
+    @Path("/get_user_streaks")
+    @Produces(MediaType.APPLICATION_JSON)
+    @GZIP
+    public Response getUserStreaks(@Context final Request request, @Context final HttpServletRequest httpServletRequest) {
+
+        try {
+            if (isUserAnAdmin(httpServletRequest)) {
+                Map<String, Object> result = Maps.newHashMap();
+
+                result.put("streakStatistics", kafkaStatsManager.getStreakStatistics());
+                return Response.ok(result).build();
+
+            } else {
+                return new SegueErrorResponse(Status.FORBIDDEN,
+                        "You must be logged in as an admin to access this function.").toResponse();
+            }
+
+        } catch (NoUserLoggedInException e) {
+            return SegueErrorResponse.getNotLoggedInResponse();
+        }
+    }
+
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/KafkaStatisticsManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/KafkaStatisticsManager.java
@@ -608,6 +608,21 @@ public class KafkaStatisticsManager implements IStatisticsManager {
         return userStatisticsStreamsApplication.getUserSnapshot(userOfInterest);
     }
 
+    public List<Map.Entry<Long, Map<String, Long>>> getStreakStatistics() {
+
+        List<Map.Entry<Long, Map<String, Long>>> streakStats =
+                new ArrayList<>(userStatisticsStreamsApplication.getAllUserStreaks().entrySet());
+
+        streakStats.sort(
+                Comparator.comparing(o -> o.getValue().get("largestStreak"))
+        );
+
+        // sort descending
+        Collections.reverse(streakStats);
+
+        return streakStats;
+    }
+
 
     /**
      * Utility method for returning a boolean value specifying if a user has been seen within a given time frame.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/kafkaStreams/UserStatisticsStreamsApplication.java
@@ -587,8 +587,9 @@ public class UserStatisticsStreamsApplication {
     }
 
     /**
+     *Method to return streak data for all users, including current and largest streaks
      *
-     * @return
+     * @return map of user ids to streak records
      */
     public Map<Long, Map<String, Long>> getAllUserStreaks() {
 


### PR DESCRIPTION
Allows admins to request a a record of all user's streak data, including current/largest streaks. Records are sorted by largest streak.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - Injection - everything run by an interpreter (SQL, OS...) is either validated or escaped
- [ ] Security - Data Exposure - PII is not stored or sent unencrypted
- [ ] Security - Access Control - Check authorisation on every new endpoint
- [ ] Security - New dependency - configured sensibly not relying on defaults
- [ ] Security - New dependency - Searched for any know vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] DB schema changes - postgres-rutherford-create-script updated
- [ ] DB schema changes - upgrade script created matching create script
- [ ] Updated Release Procedure & Documentation (& Considered Implications to Previous Versions)
- [ ] Peer-Reviewed
