### PR TITLE
Allow additional group managers to see all assignments in group CSV file

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -531,14 +531,14 @@ public class AssignmentFacade extends AbstractIsaacFacade {
             UserGroupDTO group;
             group = this.groupManager.getGroupById(groupId);
 
-            // Check the group owner:
+            // Check the user has permission to access this group:
             if (!GroupManager.isOwnerOrAdditionalManager(group, currentlyLoggedInUser.getId())
                 && !isUserAnAdmin(userManager, request)) {
                 return new SegueErrorResponse(Status.FORBIDDEN,
                         "You can only view the results of assignments that you own.").toResponse();
             }
 
-            // Fetch the assignments owned by the currently logged in user that are assigned to the requested group
+            // Fetch all assignments set to the requested group:
             List<AssignmentDTO> assignments;
             assignments = this.assignmentManager.getAllAssignmentsForSpecificGroups(Collections.singletonList(group));
 

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/api/AssignmentFacade.java
@@ -540,7 +540,7 @@ public class AssignmentFacade extends AbstractIsaacFacade {
 
             // Fetch the assignments owned by the currently logged in user that are assigned to the requested group
             List<AssignmentDTO> assignments;
-            assignments = this.assignmentManager.getAllAssignmentsSetByUserToGroup(currentlyLoggedInUser, group);
+            assignments = this.assignmentManager.getAllAssignmentsForSpecificGroups(Collections.singletonList(group));
 
             // Fetch the members of the requested group
             List<RegisteredUserDTO> groupMembers;


### PR DESCRIPTION
The method previously only listed assignments the current users had set to the group, not all the assignments the group has.
This is still restricted to the whitelisted group managers.

---

**Pull Request Check List**
- [x] Security - Access Control - Check authorisation on every new endpoint
