### PR TITLE
Feature/979 admin user tweaks

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/dao/EventBookingPersistenceManager.java
@@ -24,7 +24,7 @@ import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.content.IContentManager;
 import uk.ac.cam.cl.dtg.segue.database.PostgresSqlDb;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryWithEmailAddressDTO;
 
 import static uk.ac.cam.cl.dtg.segue.api.Constants.CONTENT_INDEX;
 
@@ -245,8 +245,8 @@ public class EventBookingPersistenceManager {
         EventBookingDTO result = new EventBookingDTO();
 
         try {
-            DetailedUserSummaryDTO user = userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(eb
-                    .getUserId()));
+            UserSummaryWithEmailAddressDTO user = userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(eb
+                    .getUserId()), UserSummaryWithEmailAddressDTO.class);
 
             result.setBookingId(eb.getId());
             result.setEventDate(eventInformation.getDate());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -15,7 +15,6 @@
  */
 package uk.ac.cam.cl.dtg.segue.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.inject.name.Named;
@@ -98,6 +97,7 @@ import uk.ac.cam.cl.dtg.segue.dto.ResultsWrapper;
 import uk.ac.cam.cl.dtg.segue.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentDTO;
 import uk.ac.cam.cl.dtg.segue.dto.content.ContentSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryForAdminUsersDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.etl.GithubPushEventPayload;
 import uk.ac.cam.cl.dtg.segue.search.SegueSearchException;
@@ -822,7 +822,9 @@ public class AdminFacade extends AbstractSegueFacade {
             log.info(String.format("%s user (%s) did a search across all users based on user prototype {%s}",
                     currentUser.getRole(), currentUser.getEmail(), userPrototype));
 
-            return Response.ok(findUsers).tag(etag).cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
+            return Response.ok(this.userManager.convertToDetailedUserSummaryObjectList(findUsers, UserSummaryForAdminUsersDTO.class))
+                    .tag(etag)
+                    .cacheControl(getCacheControl(NEVER_CACHE_WITHOUT_ETAG_CHECK, false))
                     .build();
         } catch (SegueDatabaseException e) {
             return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -194,6 +194,34 @@ public class AdminFacade extends AbstractSegueFacade {
     }
 
     /**
+     * Statistics endpoint.
+     *
+     * @param request
+     *            - to determine access.
+     * @return stats
+     */
+    @GET
+    @Path("/stats/users")
+    @Produces(MediaType.APPLICATION_JSON)
+    @GZIP
+    public Response countUsersByRole(@Context final HttpServletRequest request) {
+        try {
+            if (!isUserStaff(request)) {
+                return new SegueErrorResponse(Status.FORBIDDEN, "You must be an admin to access this endpoint.")
+                        .toResponse();
+            }
+
+            return Response.ok(userManager.getCountsForUsersByRole())
+                    .cacheControl(getCacheControl(NUMBER_SECONDS_IN_MINUTE, false)).build();
+        } catch (SegueDatabaseException e) {
+            log.error("Unable to load general statistics.", e);
+            return new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR, "Database error", e).toResponse();
+        } catch (NoUserLoggedInException e) {
+            return SegueErrorResponse.getNotLoggedInResponse();
+        }
+    }
+
+    /**
      * Locations stats.
      * 
      * @param request

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AdminFacade.java
@@ -211,7 +211,7 @@ public class AdminFacade extends AbstractSegueFacade {
                         .toResponse();
             }
 
-            return Response.ok(userManager.getCountsForUsersByRole())
+            return Response.ok(ImmutableMap.of("role", userManager.getCountsForUsersByRole()))
                     .cacheControl(getCacheControl(NUMBER_SECONDS_IN_MINUTE, false)).build();
         } catch (SegueDatabaseException e) {
             log.error("Unable to load general statistics.", e);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthorisationFacade.java
@@ -38,7 +38,7 @@ import uk.ac.cam.cl.dtg.segue.dos.AssociationToken;
 import uk.ac.cam.cl.dtg.segue.dos.UserAssociation;
 import uk.ac.cam.cl.dtg.segue.dto.SegueErrorResponse;
 import uk.ac.cam.cl.dtg.segue.dto.UserGroupDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryWithEmailAddressDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
@@ -121,7 +121,7 @@ public class AuthorisationFacade extends AbstractSegueFacade {
                 userIdsWithAccess.add(a.getUserIdReceivingPermission());
             }
 
-            return Response.ok(userManager.convertToDetailedUserSummaryObjectList(userManager.findUsers(userIdsWithAccess)))
+            return Response.ok(userManager.convertToDetailedUserSummaryObjectList(userManager.findUsers(userIdsWithAccess), UserSummaryWithEmailAddressDTO.class))
                     .cacheControl(getCacheControl(Constants.NEVER_CACHE_WITHOUT_ETAG_CHECK, false)).build();
         } catch (NoUserLoggedInException e) {
             return SegueErrorResponse.getNotLoggedInResponse();
@@ -381,8 +381,8 @@ public class AuthorisationFacade extends AbstractSegueFacade {
                     TokenOwnerLookupMisuseHandler.class.toString());
 
             // add owner
-            List<DetailedUserSummaryDTO> usersLinkedToToken = Lists.newArrayList();
-            usersLinkedToToken.add(userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(associationToken.getOwnerUserId())));
+            List<UserSummaryWithEmailAddressDTO> usersLinkedToToken = Lists.newArrayList();
+            usersLinkedToToken.add(userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(associationToken.getOwnerUserId()), UserSummaryWithEmailAddressDTO.class));
 
             // add additional managers
             usersLinkedToToken.addAll(group.getAdditionalManagers());

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.users.IUserGroupPersistenceManager;
 import uk.ac.cam.cl.dtg.segue.dos.UserGroup;
 import uk.ac.cam.cl.dtg.segue.dto.UserGroupDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryWithEmailAddressDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 
 import java.util.Comparator;
@@ -71,7 +71,7 @@ public class GroupManager {
         this.userManager = userManager;
         this.dtoMapper = dtoMapper;
 
-        groupsObservers = new LinkedList<IGroupObserver>();
+        groupsObservers = new LinkedList<>();
     }
 
     /**
@@ -163,7 +163,7 @@ public class GroupManager {
      * @param ownerUser
      *            - the owner of the groups to search for.
      * @return List of groups or empty list.
-     * @throws SegueDatabaseException
+     * @throws SegueDatabaseException if there is a db error
      */
     public List<UserGroupDTO> getGroupsByOwner(final RegisteredUserDTO ownerUser) throws SegueDatabaseException {
         Validate.notNull(ownerUser);
@@ -182,7 +182,7 @@ public class GroupManager {
      *            if true then only archived groups will be returned,
      *            if false then only unarchived groups will be returned.
      * @return List of groups or empty list.
-     * @throws SegueDatabaseException
+     * @throws SegueDatabaseException if there is a db error
      */
     public List<UserGroupDTO> getAllGroupsOwnedAndManagedByUser(final RegisteredUserDTO ownerUser, boolean archivedGroupsOnly) throws SegueDatabaseException {
         Validate.notNull(ownerUser);
@@ -201,7 +201,7 @@ public class GroupManager {
      *            if true then only archived groups will be returned,
      *            if false then only unarchived groups will be returned.
      * @return List of groups or empty list.
-     * @throws SegueDatabaseException 
+     * @throws SegueDatabaseException if there is a db error
      */
     public List<UserGroupDTO> getGroupsByOwner(final RegisteredUserDTO ownerUser, boolean archivedGroupsOnly) throws SegueDatabaseException {
         Validate.notNull(ownerUser);
@@ -303,7 +303,7 @@ public class GroupManager {
      * @param group - group to grant permission for
      * @param userToAdd - user to grant permission to
      * @return The group DTO
-     * @throws SegueDatabaseException
+     * @throws SegueDatabaseException if there is a db error
      */
     public UserGroupDTO addUserToManagerList(final UserGroupDTO group, final RegisteredUserDTO userToAdd) throws SegueDatabaseException {
         Validate.notNull(group);
@@ -329,7 +329,7 @@ public class GroupManager {
      * @param group - group to affect
      * @param userToAdd - user to remove from the management list
      * @return The group DTO
-     * @throws SegueDatabaseException
+     * @throws SegueDatabaseException if there is a db error
      */
     public UserGroupDTO removeUserFromManagerList(final UserGroupDTO group, final RegisteredUserDTO userToAdd) throws SegueDatabaseException {
         Validate.notNull(group);
@@ -378,7 +378,7 @@ public class GroupManager {
     
     /**
      * @return the total number of groups stored in the database.
-     * @throws SegueDatabaseException 
+     * @throws SegueDatabaseException if there is a db error
      */
     public Long getGroupCount() throws SegueDatabaseException {
         return groupDatabase.getGroupCount();
@@ -423,17 +423,17 @@ public class GroupManager {
         UserGroupDTO dtoToReturn = dtoMapper.map(group, UserGroupDTO.class);
 
         try {
-            dtoToReturn.setOwnerSummary(userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(group.getOwnerId())));
+            dtoToReturn.setOwnerSummary(userManager.convertToDetailedUserSummaryObject(userManager.getUserDTOById(group.getOwnerId()), UserSummaryWithEmailAddressDTO.class));
         } catch (NoUserException e) {
             // This should never happen!
             log.error(String.format("Group (%s) has owner ID (%s) that no longer exists!", group.getId(), group.getOwnerId()));
         }
 
-        Set<DetailedUserSummaryDTO> setOfUsers = Sets.newHashSet();
+        Set<UserSummaryWithEmailAddressDTO> setOfUsers = Sets.newHashSet();
         Set<Long> additionalManagers = this.groupDatabase.getAdditionalManagerSetByGroupId(group.getId());
 
         if (additionalManagers != null) {
-            setOfUsers.addAll(userManager.convertToDetailedUserSummaryObjectList(userManager.findUsers(additionalManagers)));
+            setOfUsers.addAll(userManager.convertToDetailedUserSummaryObjectList(userManager.findUsers(additionalManagers), UserSummaryWithEmailAddressDTO.class));
         }
 
         dtoToReturn.setAdditionalManagers(setOfUsers);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -60,7 +60,6 @@ import uk.ac.cam.cl.dtg.segue.comm.EmailManager;
 import uk.ac.cam.cl.dtg.segue.comm.EmailMustBeVerifiedException;
 import uk.ac.cam.cl.dtg.segue.comm.EmailType;
 import uk.ac.cam.cl.dtg.segue.dao.ILogManager;
-import uk.ac.cam.cl.dtg.segue.dao.ResourceNotFoundException;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dao.content.ContentManagerException;
 import uk.ac.cam.cl.dtg.segue.dao.users.IUserDataManager;
@@ -74,7 +73,7 @@ import uk.ac.cam.cl.dtg.segue.dto.users.AbstractSegueUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.AnonymousUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryWithEmailAddressDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
 import com.google.api.client.util.Lists;
@@ -1092,7 +1091,7 @@ public class UserAccountManager implements IUserAccountManager {
     }
 
     /**
-     * Helper method to convert a user object into a cutdown userSummary DTO.
+     * Helper method to convert a user object into a userSummary DTO with as little detail as possible about the user.
      * 
      * @param userToConvert
      *            - full user object.
@@ -1103,14 +1102,16 @@ public class UserAccountManager implements IUserAccountManager {
     }
 
     /**
-     * Helper method to convert a user object into a cutdown detailedUserSummary DTO.
+     * Helper method to convert a user object into a more detailed summary object depending on the dto provided.
      *
      * @param userToConvert
      *            - full user object.
+     * @param detailedDTOClass
+     *            - The level of detail required for the conversion
      * @return a summarised object with reduced personal information
      */
-    public DetailedUserSummaryDTO convertToDetailedUserSummaryObject(final RegisteredUserDTO userToConvert) {
-        return this.dtoMapper.map(userToConvert, DetailedUserSummaryDTO.class);
+    public UserSummaryWithEmailAddressDTO convertToDetailedUserSummaryObject(final RegisteredUserDTO userToConvert, final Class<? extends UserSummaryWithEmailAddressDTO> detailedDTOClass) {
+        return this.dtoMapper.map(userToConvert, detailedDTOClass);
     }
 
     /**
@@ -1134,13 +1135,15 @@ public class UserAccountManager implements IUserAccountManager {
      *
      * @param userListToConvert
      *            - full user objects.
+     * @param detailedDTO
+     *            - The level of detail required for the conversion
      * @return a list of summarised objects with reduced personal information
      */
-    public List<DetailedUserSummaryDTO> convertToDetailedUserSummaryObjectList(final List<RegisteredUserDTO> userListToConvert) {
+    public List<UserSummaryWithEmailAddressDTO> convertToDetailedUserSummaryObjectList(final List<RegisteredUserDTO> userListToConvert, final Class<? extends UserSummaryWithEmailAddressDTO> detailedDTO) {
         Validate.notNull(userListToConvert);
-        List<DetailedUserSummaryDTO> resultList = Lists.newArrayList();
+        List<UserSummaryWithEmailAddressDTO> resultList = Lists.newArrayList();
         for (RegisteredUserDTO user : userListToConvert) {
-            resultList.add(this.convertToDetailedUserSummaryObject(user));
+            resultList.add(this.convertToDetailedUserSummaryObject(user, detailedDTO));
         }
         return resultList;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/managers/UserAccountManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins & Nick Rogers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,7 +127,7 @@ public class UserAccountManager implements IUserAccountManager {
             final UserAuthenticationManager userAuthenticationManager) {
         this(database, questionDb, properties, providersToRegister, dtoMapper, emailQueue, CacheBuilder.newBuilder()
                 .expireAfterAccess(ANONYMOUS_SESSION_DURATION_IN_MINUTES, TimeUnit.MINUTES)
-                .<String, AnonymousUser> build(), logManager, userAuthenticationManager);
+                .build(), logManager, userAuthenticationManager);
     }
 
     /**
@@ -158,7 +158,7 @@ public class UserAccountManager implements IUserAccountManager {
             final Cache<String, AnonymousUser> temporaryUserCache, final ILogManager logManager,
             final UserAuthenticationManager userAuthenticationManager) {
         Validate.notNull(properties.getProperty(HMAC_SALT));
-        Validate.notNull(Integer.parseInt(properties.getProperty(SESSION_EXPIRY_SECONDS)));
+        Validate.notNull(properties.getProperty(SESSION_EXPIRY_SECONDS));
         Validate.notNull(properties.getProperty(HOST_NAME));
 
         this.properties = properties;
@@ -1149,6 +1149,14 @@ public class UserAccountManager implements IUserAccountManager {
     }
 
     /**
+     * Method to retrieve the number of users by role from the Database.
+     * @return a map of role to counter
+     */
+    public Map<Role, Integer> getCountsForUsersByRole() throws SegueDatabaseException {
+        return this.database.countUsersByRole();
+    }
+
+    /**
      * Sends verification email for the user's current email address. The destination will match the userDTO's email.
      * @param userDTO - user to which the email is to be sent.
      * @param emailVerificationToken - the generated email verification token.
@@ -1494,9 +1502,9 @@ public class UserAccountManager implements IUserAccountManager {
     }
 
     /**
-     * @param userDTO
-     * @param emailVerificationToken
-     * @return
+     * @param userDTO the userDTO of interest
+     * @param emailVerificationToken the verifcation token
+     * @return verification URL
      */
     private String generateEmailVerificationURL(final RegisteredUserDTO userDTO, final String emailVerificationToken) {
         List<NameValuePair> urlParamPairs = Lists.newArrayList();
@@ -1508,17 +1516,13 @@ public class UserAccountManager implements IUserAccountManager {
         return String.format("https://%s/verifyemail?%s", properties.getProperty(HOST_NAME), urlParams);
     }
 
-
-
     public Boolean isValidUserFromSession(final Map<String, String> sessionInformation) {
 
         return this.userAuthenticationManager.isValidUsersSession(sessionInformation);
     }
 
-
     public Long getNumberOfAnonymousUsers() {
         return temporaryUserCache.size();
     }
-
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/IUserDataManager.java
@@ -17,10 +17,12 @@ package uk.ac.cam.cl.dtg.segue.dao.users;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import uk.ac.cam.cl.dtg.segue.auth.AuthenticationProvider;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
 import uk.ac.cam.cl.dtg.segue.dos.users.RegisteredUser;
+import uk.ac.cam.cl.dtg.segue.dos.users.Role;
 
 /**
  * Interface for managing and persisting user specific data in segue.
@@ -168,6 +170,14 @@ public interface IUserDataManager {
      *             - if there is a problem with the database.
      */
     List<RegisteredUser> findUsers(List<Long> usersToLocate) throws SegueDatabaseException;
+
+    /**
+     * Count all the users by role and return a map
+     * @return map of user role to integers
+     * @throws SegueDatabaseException
+     *             - if there is a problem with the database.
+     */
+    Map<Role, Integer> countUsersByRole() throws SegueDatabaseException;
 
     /**
      * Get a user by email verification token.

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dao/users/PgUsers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -350,6 +350,25 @@ public class PgUsers implements IUserDataManager {
         } catch (SQLException e) {
             throw new SegueDatabaseException("Postgres exception", e);
         }  
+    }
+
+    @Override
+    public Map<Role, Integer> countUsersByRole() throws SegueDatabaseException {
+        try (Connection conn = database.getDatabaseConnection()) {
+            PreparedStatement pst;
+            pst = conn.prepareStatement("select role, count(1) from users group by role;");
+
+            ResultSet results = pst.executeQuery();
+            Map<Role, Integer> resultToReturn = Maps.newHashMap();
+
+            while (results.next()) {
+                resultToReturn.put(Role.valueOf(results.getString("role")), results.getInt("count"));
+            }
+
+            return resultToReturn;
+        } catch (SQLException e) {
+            throw new SegueDatabaseException("Postgres exception", e);
+        }
     }
 
     @Override

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/RegisteredUser.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dos/users/RegisteredUser.java
@@ -111,6 +111,7 @@ public class RegisteredUser extends AbstractSegueUser {
      * @return the id
      */
     @JsonProperty("_id")
+    //TODO: Deprecate all usage of old mongo ids e.g. _id
     public Long getId() {
         return id;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/UserGroupDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/UserGroupDTO.java
@@ -16,7 +16,6 @@
 package uk.ac.cam.cl.dtg.segue.dto;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,7 +26,7 @@ import com.google.api.client.util.Sets;
 import org.mongojack.ObjectId;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryWithEmailAddressDTO;
 
 /**
  * UserGroupDTO - this object represents a group or label assigned to users who have been placed into a group.
@@ -41,8 +40,8 @@ public class UserGroupDTO {
     private Date created;
     private String token;
     private boolean archived;
-    private DetailedUserSummaryDTO ownerSummary;
-    private Set<DetailedUserSummaryDTO> additionalManagers;
+    private UserSummaryWithEmailAddressDTO ownerSummary;
+    private Set<UserSummaryWithEmailAddressDTO> additionalManagers;
 
     /**
      * Default Constructor.
@@ -196,7 +195,7 @@ public class UserGroupDTO {
      *
      * @return the owner summary object
      */
-    public DetailedUserSummaryDTO getOwnerSummary() {
+    public UserSummaryWithEmailAddressDTO getOwnerSummary() {
         return ownerSummary;
     }
 
@@ -206,7 +205,7 @@ public class UserGroupDTO {
      * @param ownerSummary
      *            the detailed owner summary object
      */
-    public void setOwnerSummary(final DetailedUserSummaryDTO ownerSummary) {
+    public void setOwnerSummary(final UserSummaryWithEmailAddressDTO ownerSummary) {
         this.ownerSummary = ownerSummary;
     }
 
@@ -215,7 +214,7 @@ public class UserGroupDTO {
      *
      * @return list of user ids
      */
-    public Set<DetailedUserSummaryDTO> getAdditionalManagers() {
+    public Set<UserSummaryWithEmailAddressDTO> getAdditionalManagers() {
         return additionalManagers;
     }
 
@@ -224,7 +223,7 @@ public class UserGroupDTO {
      *
      * @param additionalManagers - those users who should have access to this group.
      */
-    public void setAdditionalManagers(Set<DetailedUserSummaryDTO> additionalManagers) {
+    public void setAdditionalManagers(Set<UserSummaryWithEmailAddressDTO> additionalManagers) {
         this.additionalManagers = additionalManagers;
     }
 
@@ -269,6 +268,6 @@ public class UserGroupDTO {
      */
     @JsonIgnore
     public Set<Long> getAdditionalManagersUserIds() {
-        return additionalManagers.stream().map(DetailedUserSummaryDTO::getId).collect(Collectors.toSet());
+        return additionalManagers.stream().map(UserSummaryWithEmailAddressDTO::getId).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Stephen Cummins
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ import uk.ac.cam.cl.dtg.segue.dos.users.EmailVerificationStatus;
 import uk.ac.cam.cl.dtg.segue.dos.users.Role;
 
 /**
- * User Summary object.
+ * Minimal view of a User object.
  */
 public class UserSummaryDTO extends AbstractSegueUserDTO {
     private String databaseId;
@@ -62,6 +62,7 @@ public class UserSummaryDTO extends AbstractSegueUserDTO {
      * @return the databaseId
      */
     @JsonProperty("_id")
+    @Deprecated
     public String getLegacyDbId() {
         return databaseId;
     }
@@ -73,6 +74,7 @@ public class UserSummaryDTO extends AbstractSegueUserDTO {
      *            the databaseId to set
      */
     @JsonProperty("_id")
+    @Deprecated
     public void setLegacyDbId(final String databaseId) {
         this.databaseId = databaseId;
     }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryForAdminUsersDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryForAdminUsersDTO.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Stephen Cummins
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.cam.cl.dtg.segue.dto.users;
+
+import java.util.Date;
+
+/**
+ * Admin view of a User Summary object, which contains additional information (e.g. last login date).
+ */
+public class UserSummaryForAdminUsersDTO extends UserSummaryWithEmailAddressDTO {
+    private Date lastUpdated;
+    private Date lastSeen;
+    private Date registrationDate;
+
+    /**
+     * UserSummaryDTO.
+     */
+    public UserSummaryForAdminUsersDTO() {
+
+    }
+
+    /**
+     * Gets the lastUpdated.
+     *
+     * @return the lastUpdated
+     */
+    public Date getLastUpdated() {
+        return lastUpdated;
+    }
+
+    /**
+     * Sets the lastUpdated.
+     *
+     * @param lastUpdated
+     *            the lastUpdated to set
+     */
+    public void setLastUpdated(final Date lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    /**
+     * Gets the lastSeen.
+     *
+     * @return the lastSeen
+     */
+    public Date getLastSeen() {
+        return lastSeen;
+    }
+
+    /**
+     * Sets the lastSeen.
+     *
+     * @param lastSeen
+     *            the lastSeen to set
+     */
+    public void setLastSeen(final Date lastSeen) {
+        this.lastSeen = lastSeen;
+    }
+
+    /**
+     * Gets the registrationDate.
+     *
+     * @return the registrationDate
+     */
+    public Date getRegistrationDate() {
+        return registrationDate;
+    }
+
+    /**
+     * Sets the registrationDate.
+     *
+     * @param registrationDate
+     *            the registrationDate to set
+     */
+    public void setRegistrationDate(final Date registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
+    @Override
+    public String toString() {
+        return "UserSummaryForAdminUsersDTO{" +
+                "lastUpdated=" + lastUpdated +
+                ", lastSeen=" + lastSeen +
+                ", registrationDate=" + registrationDate +
+                '}';
+    }
+}

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryForAdminUsersDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryForAdminUsersDTO.java
@@ -24,6 +24,8 @@ public class UserSummaryForAdminUsersDTO extends UserSummaryWithEmailAddressDTO 
     private Date lastUpdated;
     private Date lastSeen;
     private Date registrationDate;
+    private String schoolId;
+    private String schoolOther;
 
     /**
      * UserSummaryDTO.
@@ -89,12 +91,51 @@ public class UserSummaryForAdminUsersDTO extends UserSummaryWithEmailAddressDTO 
         this.registrationDate = registrationDate;
     }
 
+    /**
+     * Gets the schoolId.
+     *
+     * @return the schoolId
+     */
+    public String getSchoolId() {
+        return schoolId;
+    }
+
+    /**
+     * Sets the schoolId.
+     *
+     * @param schoolId
+     *            the schoolId to set
+     */
+    public void setSchoolId(final String schoolId) {
+        this.schoolId = schoolId;
+    }
+
+    /**
+     * Gets the schoolOther.
+     *
+     * @return the schoolOther
+     */
+    public String getSchoolOther() {
+        return schoolOther;
+    }
+
+    /**
+     * Sets the schoolOther.
+     *
+     * @param schoolOther
+     *            the schoolOther to set
+     */
+    public void setSchoolOther(final String schoolOther) {
+        this.schoolOther = schoolOther;
+    }
+
     @Override
     public String toString() {
-        return "UserSummaryForAdminUsersDTO{" +
-                "lastUpdated=" + lastUpdated +
-                ", lastSeen=" + lastSeen +
-                ", registrationDate=" + registrationDate +
-                '}';
+        return "lastUpdated=" + "UserSummaryForAdminUsersDTO{" + lastUpdated
+                + ", lastSeen=" + lastSeen
+                + ", registrationDate=" + registrationDate
+                + ", schoolId=" + schoolId
+                + ", schoolOther=" + schoolOther
+                + '}';
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryWithEmailAddressDTO.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/dto/users/UserSummaryWithEmailAddressDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +16,15 @@
 package uk.ac.cam.cl.dtg.segue.dto.users;
 
 /**
- * Teacher User Summary object, which contains additional information (email).
+ * View of a User Summary object, which contains additional information (email). Usually used where a sharing relationship has or will be created.
  */
-public class DetailedUserSummaryDTO extends UserSummaryDTO {
+public class UserSummaryWithEmailAddressDTO extends UserSummaryDTO {
     private String email;
 
     /**
      * UserSummaryDTO.
      */
-    public DetailedUserSummaryDTO() {
+    public UserSummaryWithEmailAddressDTO() {
 
     }
 

--- a/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManagerTest.java
+++ b/src/test/java/uk/ac/cam/cl/dtg/segue/api/managers/GroupManagerTest.java
@@ -37,11 +37,10 @@ import uk.ac.cam.cl.dtg.segue.api.Constants;
 import uk.ac.cam.cl.dtg.segue.comm.EmailCommunicationMessage;
 import uk.ac.cam.cl.dtg.segue.comm.ICommunicator;
 import uk.ac.cam.cl.dtg.segue.dao.SegueDatabaseException;
-import uk.ac.cam.cl.dtg.segue.dao.content.ContentMapper;
 import uk.ac.cam.cl.dtg.segue.dao.users.IUserGroupPersistenceManager;
 import uk.ac.cam.cl.dtg.segue.dos.UserGroup;
 import uk.ac.cam.cl.dtg.segue.dto.UserGroupDTO;
-import uk.ac.cam.cl.dtg.segue.dto.users.DetailedUserSummaryDTO;
+import uk.ac.cam.cl.dtg.segue.dto.users.UserSummaryWithEmailAddressDTO;
 import uk.ac.cam.cl.dtg.segue.dto.users.RegisteredUserDTO;
 import uk.ac.cam.cl.dtg.util.PropertiesLoader;
 
@@ -95,7 +94,7 @@ public class GroupManagerTest {
 		Capture<UserGroup> capturedGroup = new Capture<UserGroup>();
 
 		List<RegisteredUserDTO> someListOfUsers = Lists.newArrayList();
-		List<DetailedUserSummaryDTO> someListOfUsersDTOs = Lists.newArrayList();
+		List<UserSummaryWithEmailAddressDTO> someListOfUsersDTOs = Lists.newArrayList();
 
 		UserGroup resultFromDB = new UserGroup();
 		resultFromDB.setId(2L);
@@ -109,7 +108,7 @@ public class GroupManagerTest {
 			expect(this.groupDataManager.getAdditionalManagerSetByGroupId(anyObject()))
 					.andReturn(someSetOfManagers).atLeastOnce();
 			expect(this.userManager.findUsers(someSetOfManagers)).andReturn(someListOfUsers);
-			expect(this.userManager.convertToDetailedUserSummaryObjectList(someListOfUsers)).andReturn(someListOfUsersDTOs);
+			expect(this.userManager.convertToDetailedUserSummaryObjectList(someListOfUsers, UserSummaryWithEmailAddressDTO.class)).andReturn(someListOfUsersDTOs);
 			expect(this.dummyMapper.map(resultFromDB, UserGroupDTO.class)).andReturn(mappedGroup).atLeastOnce();
 
 			replay(this.userManager, this.groupDataManager, this.dummyMapper);


### PR DESCRIPTION
Refactored DTOs a little bit to expose less information to admin users.

Also added a count users by role endpoint to power the email users page which currently tries to use the awful stats endpoint. To benefit from this the equivalent frontend PR will need to be reviewed and merged too.
