### PR TITLE
Adds `LOG_IN` event type to logged events table

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/AuthenticationFacade.java
@@ -234,7 +234,9 @@ public class AuthenticationFacade extends AbstractSegueFacade {
             @Context final HttpServletResponse response, @PathParam("provider") final String signinProvider) {
 
         try {
-            return Response.ok(userManager.authenticateCallback(request, response, signinProvider)).build();
+            RegisteredUserDTO userToReturn = userManager.authenticateCallback(request, response, signinProvider);
+            this.getLogManager().logEvent(userToReturn, request, SegueLogType.LOG_IN, Maps.newHashMap());
+            return Response.ok(userToReturn).build();
         } catch (IOException e) {
             SegueErrorResponse error = new SegueErrorResponse(Status.INTERNAL_SERVER_ERROR,
                     "Exception while trying to authenticate a user" + " - during callback step.", e);
@@ -316,9 +318,9 @@ public class AuthenticationFacade extends AbstractSegueFacade {
 
         // ok we need to hand over to user manager
         try {
-            return Response
-                    .ok(userManager.authenticateWithCredentials(request, response, signinProvider, email, password))
-                    .build();
+            RegisteredUserDTO userToReturn = userManager.authenticateWithCredentials(request, response, signinProvider, email, password);
+            this.getLogManager().logEvent(userToReturn, request, SegueLogType.LOG_IN, Maps.newHashMap());
+            return Response.ok(userToReturn).build();
         } catch (AuthenticationProviderMappingException e) {
             String errorMsg = "Unable to locate the provider specified";
             log.error(errorMsg, e);

--- a/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/segue/api/Constants.java
@@ -287,6 +287,7 @@ public final class Constants {
         EVENT_BOOKING,
         EVENT_BOOKING_CANCELLED,
         EVENT_WAITING_LIST_BOOKING,
+        LOG_IN,
         LOG_OUT,
         MERGE_USER,
         PASSWORD_RESET_REQUEST_RECEIVED,


### PR DESCRIPTION
Writes the `LOG_IN` event to the `logged_events` table as an `event_type`. Currently only writes on a successful login (username/password or external provider). Very similar to the `LOG_OUT` event type.

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [x] Added enough Logging to monitor expected behaviour change
- [x] Security - Data Exposure - PII is not stored or sent unencrypted
