### PR TITLE
Directly use Postgres Docker image rather than a pre-built Isaac one

### DIFF
--- a/compose-local-deps.yml
+++ b/compose-local-deps.yml
@@ -29,7 +29,14 @@ services:
   postgres:
     network_mode: bridge
     container_name: postgres
-    image: isaac-pg
+    image: postgres:9.6
+    volumes:
+      - pg-local:/var/lib/postgresql/data
+      - ./src/main/resources/db_scripts/postgres-rutherford-create-script.sql:/docker-entrypoint-initdb.d/00-isaac-create.sql:ro
+      - ./src/main/resources/db_scripts/postgres-rutherford-functions.sql:/docker-entrypoint-initdb.d/01-isaac-functions.sql:ro
+    environment:
+      POSTGRES_USER: rutherford
+      POSTGRES_PASSWORD: rutherf0rd
     ports:
       - "5432:5432"
   app-physics:
@@ -63,3 +70,6 @@ networks:
   default:
     external:
       name: bridge
+volumes:
+  pg-local:
+    external: true

--- a/src/main/resources/db_scripts/Dockerfile
+++ b/src/main/resources/db_scripts/Dockerfile
@@ -1,7 +1,0 @@
-FROM postgres:9.6
-COPY postgres-rutherford-create-script.sql /docker-entrypoint-initdb.d/00-isaac-create.sql
-COPY postgres-rutherford-functions.sql /docker-entrypoint-initdb.d/01-isaac-functions.sql
-
-ENV PGDATA /pgdata
-ENV POSTGRES_USER rutherford
-ENV POSTGRES_PASSWORD rutherf0rd

--- a/src/main/resources/db_scripts/README.md
+++ b/src/main/resources/db_scripts/README.md
@@ -1,8 +1,6 @@
 # Isaac Docker Database Configuration
 
 ### Scripts
-Running `build-pg-image.sh` will create or update the `isaac-pg` PostgreSQL image that will initialise itself with a blank 'rutherford' database on first start.
-It is used for local development and non-production databases on the server. 
 
 `dump-db.sh` is a script for dumping one of the server databases and takes the environment as its first argument. The command it contains can be adapted to dump a local database if required by replacing `pg-$1` with `postgres`.
 

--- a/src/main/resources/db_scripts/build-pg-image.sh
+++ b/src/main/resources/db_scripts/build-pg-image.sh
@@ -1,1 +1,0 @@
-docker build -t isaac-pg .


### PR DESCRIPTION
This avoids the need for building a pretty pointless image, and adds a volume so that local databases are persisted. 

*WARNING*
This updates the local postgres image and container definition. If you run `docker-compose -f compose-api-deps.yml up -d` _you will lose your local database_!

I strongly recommend doing the following:
1) Dump your local database: `docker exec -i postgres pg_dump --username=rutherford --clean > postgres.sql`
2) Pull these changes.
3) Create a new Docker volume for the data: `docker volume create --name=pg-local`
4) Update your local postgres: `docker-compose -f compose-local-deps.yml up -d postgres`
5) Restore your local database: `docker exec -i postgres psql -U rutherford -f - --quiet < postgres.sql`
6) Delete the temporary file: `rm postgres.sql`