### PR TITLE
Refactor validators

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -15,16 +15,9 @@
  */
 package uk.ac.cam.cl.dtg.isaac.quiz;
 
-import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import uk.ac.cam.cl.dtg.isaac.dos.IsaacNumericQuestion;
 import uk.ac.cam.cl.dtg.segue.dos.QuantityValidationResponse;
 import uk.ac.cam.cl.dtg.segue.dos.QuestionValidationResponse;
@@ -33,6 +26,12 @@ import uk.ac.cam.cl.dtg.segue.dos.content.Content;
 import uk.ac.cam.cl.dtg.segue.dos.content.Quantity;
 import uk.ac.cam.cl.dtg.segue.dos.content.Question;
 import uk.ac.cam.cl.dtg.segue.quiz.IValidator;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -195,16 +195,9 @@ public class IsaacNumericValidator implements IValidator {
         int sigFigsToValidateWith = numberOfSignificantFiguresToValidateWith(answerFromUser.getValue(),
                       isaacNumericQuestion.getSignificantFiguresMin(), isaacNumericQuestion.getSignificantFiguresMax());
 
-        List<Choice> orderedChoices = Lists.newArrayList(isaacNumericQuestion.getChoices());
-
-        Collections.sort(orderedChoices, (o1, o2) -> {
-            int o1Val = o1.isCorrect() ? 0 : 1;
-            int o2Val = o2.isCorrect() ? 0 : 1;
-            return o1Val - o2Val;
-        });
-
         String unitsFromUser = answerFromUser.getUnits().trim();
 
+        List<Choice> orderedChoices = getOrderedChoices(isaacNumericQuestion.getChoices());
         for (Choice c : orderedChoices) {
             if (c instanceof Quantity) {
                 Quantity quantityFromQuestion = (Quantity) c;
@@ -267,13 +260,7 @@ public class IsaacNumericValidator implements IValidator {
         int sigFigsToValidateWith = numberOfSignificantFiguresToValidateWith(answerFromUser.getValue(),
                 isaacNumericQuestion.getSignificantFiguresMin(), isaacNumericQuestion.getSignificantFiguresMax());
 
-        List<Choice> orderedChoices = Lists.newArrayList(isaacNumericQuestion.getChoices());
-
-        Collections.sort(orderedChoices, (o1, o2) -> {
-            int o1Val = o1.isCorrect() ? 0 : 1;
-            int o2Val = o2.isCorrect() ? 0 : 1;
-            return o1Val - o2Val;
-        });
+        List<Choice> orderedChoices = getOrderedChoices(isaacNumericQuestion.getChoices());
 
         for (Choice c : orderedChoices) {
             if (c instanceof Quantity) {
@@ -305,6 +292,24 @@ public class IsaacNumericValidator implements IValidator {
         } else {
             return bestResponse;
         }
+    }
+
+    /**
+     * Create a new list of the Choice objects, sorted into correct-first order for checking.
+     *
+     * @param choices - the Choices from a Question
+     * @return the ordered list of Choices
+     */
+    private List<Choice> getOrderedChoices(final List<Choice> choices) {
+        List<Choice> orderedChoices = Lists.newArrayList(choices);
+
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = o1.isCorrect() ? 0 : 1;
+            int o2Val = o2.isCorrect() ? 0 : 1;
+            return o1Val - o2Val;
+        });
+
+        return orderedChoices;
     }
 
     /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -202,8 +202,7 @@ public class IsaacNumericValidator implements IValidator {
                 Quantity quantityFromQuestion = (Quantity) c;
 
                 if (quantityFromQuestion.getUnits() == null) {
-                    log.error("Expected units and no units can be found for question id: "
-                            + isaacNumericQuestion.getId());
+                    log.error("Expected units and no units can be found for question id: " + isaacNumericQuestion.getId());
                     continue;
                 }
 
@@ -211,20 +210,20 @@ public class IsaacNumericValidator implements IValidator {
 
                 boolean numericValuesMatched = numericValuesMatch(quantityFromQuestion.getValue(), answerFromUser.getValue(),
                         sigFigsToValidateWith);
-                // match known choices
-                if (numericValuesMatched && unitsFromUser.equals(unitsFromChoice)) {
 
-                    // exact match
+                // What sort of match do we have:
+                if (numericValuesMatched && unitsFromUser.equals(unitsFromChoice)) {
+                    // Exact match: nothing else can do better.
                     bestResponse = new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
                             quantityFromQuestion.isCorrect(), (Content) quantityFromQuestion.getExplanation(),
                             quantityFromQuestion.isCorrect(), quantityFromQuestion.isCorrect(), new Date());
                     break;
                 } else if (numericValuesMatched && !unitsFromUser.equals(unitsFromChoice) && quantityFromQuestion.isCorrect()) {
-                    // matches value but not units of a correct choice.
+                    // Matches value but not units of a correct choice.
                     bestResponse = new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
                             false, new Content(DEFAULT_WRONG_UNIT_VALIDATION_RESPONSE), true, false, new Date());
                 } else if (!numericValuesMatched && unitsFromUser.equals(unitsFromChoice) && quantityFromQuestion.isCorrect()) {
-                    // matches units but not value of a correct choice.
+                    // Matches units but not value of a correct choice.
                     bestResponse = new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
                             false, new Content(DEFAULT_VALIDATION_RESPONSE), false, true, new Date());
                 }
@@ -235,7 +234,7 @@ public class IsaacNumericValidator implements IValidator {
         }
 
         if (null == bestResponse) {
-            // tell them they got it wrong but we cannot find any more detailed feedback for them.
+            // No matches; tell them they got it wrong but we cannot find any more detailed feedback for them.
             return new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser, false, new Content(
                     DEFAULT_VALIDATION_RESPONSE), false, false, new Date());
         } else {
@@ -265,10 +264,8 @@ public class IsaacNumericValidator implements IValidator {
             if (c instanceof Quantity) {
                 Quantity quantityFromQuestion = (Quantity) c;
 
-                // match known choices
+                // Do we have a match? Since only comparing values, either an exact match or not a match at all.
                 if (numericValuesMatch(quantityFromQuestion.getValue(), answerFromUser.getValue(), sigFigsToValidateWith)) {
-
-                    // value match
                     bestResponse = new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
                             quantityFromQuestion.isCorrect(), (Content) quantityFromQuestion.getExplanation(),
                             quantityFromQuestion.isCorrect(), null, new Date());
@@ -465,8 +462,8 @@ public class IsaacNumericValidator implements IValidator {
     }
     
     /**
-     * Sometimes we want to do an exact string wise match before we do sig fig checks etc. This method is intended to
-     * work for this case.
+     * To save validation effort, if we have string equality between the submitted value and an answer then we
+     * can be sure this match is the best possible.
      * 
      * @param isaacNumericQuestion
      *            - question content object

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -489,14 +489,13 @@ public class IsaacNumericValidator implements IValidator {
                     userStringForComparison.append(answerFromUser.getUnits());
                 }
 
-                StringBuilder questionAnswerStringForComparison = new StringBuilder();
-                questionAnswerStringForComparison.append(quantityFromQuestion.getValue().trim());
+                StringBuilder questionAnswerString = new StringBuilder();
+                questionAnswerString.append(quantityFromQuestion.getValue().trim());
                 if (isaacNumericQuestion.getRequireUnits()) {
-                    questionAnswerStringForComparison.append(quantityFromQuestion.getUnits());
+                    questionAnswerString.append(quantityFromQuestion.getUnits());
                 }
 
-                if (questionAnswerStringForComparison.toString().trim()
-                        .equals(userStringForComparison.toString().trim())) {
+                if (questionAnswerString.toString().trim().equals(userStringForComparison.toString().trim())) {
                     Boolean unitFeedback = null;
                     if (isaacNumericQuestion.getRequireUnits()) {
                         unitFeedback = quantityFromQuestion.getUnits().equals(answerFromUser.getUnits());

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacNumericValidator.java
@@ -274,10 +274,6 @@ public class IsaacNumericValidator implements IValidator {
                             quantityFromQuestion.isCorrect(), (Content) quantityFromQuestion.getExplanation(),
                             quantityFromQuestion.isCorrect(), null, new Date());
                     break;
-                } else {
-                    // value doesn't match this choice
-                    bestResponse = new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
-                            false, new Content(DEFAULT_VALIDATION_RESPONSE), false, null, new Date());
                 }
             } else {
                 log.error("Isaac Numeric Validator expected there to be a Quantity in ("
@@ -286,9 +282,9 @@ public class IsaacNumericValidator implements IValidator {
         }
 
         if (null == bestResponse) {
-            // tell them they got it wrong but we cannot find any more detailed feedback for them.
-            return new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser, false, null,
-                    false, false, new Date());
+            // No matches; tell them they got it wrong but we cannot find any more detailed feedback for them.
+            return new QuantityValidationResponse(isaacNumericQuestion.getId(), answerFromUser,
+                    false, new Content(DEFAULT_VALIDATION_RESPONSE), false, null, new Date());
         } else {
             return bestResponse;
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -77,12 +77,7 @@ public class IsaacStringMatchValidator implements IValidator {
         if (null == feedback) {
 
             // Sort the choices so that we match incorrect choices last, taking precedence over correct ones.
-            List<Choice> orderedChoices = Lists.newArrayList(stringMatchQuestion.getChoices());
-            orderedChoices.sort((o1, o2) -> {
-                int o1Val = o1.isCorrect() ? 0 : 1;
-                int o2Val = o2.isCorrect() ? 0 : 1;
-                return o1Val - o2Val;
-            });
+            List<Choice> orderedChoices = getOrderedChoices(stringMatchQuestion.getChoices());
 
             // For all the choices on this question...
             for (Choice c : orderedChoices) {
@@ -120,6 +115,24 @@ public class IsaacStringMatchValidator implements IValidator {
         }
 
         return new QuestionValidationResponse(question.getId(), answer, responseCorrect, feedback, new Date());
+    }
+
+    /**
+     * Create a new list of the Choice objects, sorted into correct-first order for checking.
+     *
+     * @param choices - the Choices from a Question
+     * @return the ordered list of Choices
+     */
+    private List<Choice> getOrderedChoices(final List<Choice> choices) {
+        List<Choice> orderedChoices = Lists.newArrayList(choices);
+
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = o1.isCorrect() ? 0 : 1;
+            int o2Val = o2.isCorrect() ? 0 : 1;
+            return o1Val - o2Val;
+        });
+
+        return orderedChoices;
     }
 
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacStringMatchValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 James Sharkey
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -274,56 +274,25 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                         // Input is semantically equivalent to correct answer.
                         matchType = MatchType.EXACT;
 
-                    } else if (response.get("expectedType").equals("equation")) {
-
+                    } else if (response.get("expectedType").equals("equation") || response.get("expectedType").equals("expression")) {
                         if (response.get("weaklyEquivalent").equals(false)) {
-
-                            // current choice is not a good match.
+                            // This is not a match.
                             continue;
-
                         }
-
-                        // Measure the 'weakness' level. (0 is the weakest)
+                        // Strength of match, increasing from 0.
                         int counter = 0;
-
                         if (response.get("sameState").equals(true)) {
                             counter++;
                         }
-
                         if (response.get("sameCoefficient").equals(true)) {
                             counter++;
                         }
-
-                        if (response.get("sameArrow").equals(true)) {
+                        if (response.get("expectedType").equals("equation") && response.get("sameArrow").equals(true)) {
                             counter++;
                         }
 
 
                         matchType = MatchType.valueOf("WEAK" + counter);
-
-                    } else if (response.get("expectedType").equals("expression")) {
-
-                        // Response & Answer have type Expression.
-                        if (response.get("weaklyEquivalent").equals(false)) {
-
-                            // current choice is not a good match.
-                            continue;
-
-                        }
-
-                        // Measure the 'weakness' level. (0 is the weakest)
-                        int counter = 0;
-
-                        if (response.get("sameState").equals(true)) {
-                            counter++;
-                        }
-
-                        if (response.get("sameCoefficient").equals(true)) {
-                            counter++;
-                        }
-
-                        matchType = MatchType.valueOf("WEAK" + counter);
-
                     } else {
 
                         // Response & Answer have type NuclearEquation or NuclearExpression.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -41,12 +41,9 @@ import uk.ac.cam.cl.dtg.segue.quiz.ValidatorUnavailableException;
 
 import java.io.IOException;
 import java.io.StringWriter;
-
-import java.util.HashMap;
-import java.util.Collections;
-import java.util.List;
-import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Ian Davies, James Sharkey, Ryan Lau
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,8 +48,6 @@ import java.util.Map;
 
 /**
  * Validator that only provides functionality to validate symbolic chemistry questions.
- *
- * @author Ian Davies
  *
  */
 public class IsaacSymbolicChemistryValidator implements IValidator {
@@ -290,21 +288,17 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                         if (response.get("expectedType").equals("equation") && response.get("sameArrow").equals(true)) {
                             counter++;
                         }
-
-
                         matchType = MatchType.valueOf("WEAK" + counter);
                     } else {
 
                         // Response & Answer have type NuclearEquation or NuclearExpression.
                         if (response.get("weaklyEquivalent").equals(false)) {
-
-                            // current choice is not a good match.
+                            // This is not a match
                             continue;
                         }
 
                         // Measure the 'weakness' level. (0 is the weakest)
                         int counter = 0;
-
                         // FIXME: Nuclear Equations and Expressions don't have 'sameCoefficient' property?!
                         // So ignore this for now!
 //                        if (response.get("sameCoefficient").equals(true)) {

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -95,7 +95,7 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                     answer.getClass()));
         }
 
-        IsaacSymbolicChemistryQuestion symbolicQuestion = (IsaacSymbolicChemistryQuestion) question;
+        IsaacSymbolicChemistryQuestion chemistryQuestion = (IsaacSymbolicChemistryQuestion) question;
         ChemicalFormula submittedFormula = (ChemicalFormula) answer;
 
         // These variables store the important features of the response we'll send.
@@ -116,7 +116,7 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
         // STEP 0: Do we even have any answers for this question? Always do this check, because we know we
         //         won't have feedback yet.
 
-        if (null == symbolicQuestion.getChoices() || symbolicQuestion.getChoices().isEmpty()) {
+        if (null == chemistryQuestion.getChoices() || chemistryQuestion.getChoices().isEmpty()) {
             log.error("Question does not have any answers. " + question.getId() + " src: "
                     + question.getCanonicalSourceFile());
 
@@ -135,11 +135,11 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
         if (null == feedback) {
 
             // For all the choices on this question...
-            for (Choice c : symbolicQuestion.getChoices()) {
+            for (Choice c : chemistryQuestion.getChoices()) {
 
                 // ... that are of the ChemicalFormula type, ...
                 if (!(c instanceof ChemicalFormula)) {
-                    log.error("Isaac Symbolic Chemistry Validator for questionId: " + symbolicQuestion.getId()
+                    log.error("Isaac Symbolic Chemistry Validator for questionId: " + chemistryQuestion.getId()
                             + " expected there to be a ChemicalFormula. Instead it found a Choice.");
                     continue;
                 }
@@ -149,7 +149,7 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                 // ... and that have a mhchem expression ...
                 if (null == formulaChoice.getMhchemExpression() || formulaChoice.getMhchemExpression().isEmpty()) {
                     log.error("Expected python expression, but none found in choice for question id: "
-                            + symbolicQuestion.getId());
+                            + chemistryQuestion.getId());
                     continue;
                 }
 
@@ -206,7 +206,7 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
                     HashMap<String, String> req = Maps.newHashMap();
                     req.put("target", formulaChoice.getMhchemExpression());
                     req.put("test", submittedFormula.getMhchemExpression());
-                    req.put("description", symbolicQuestion.getId());
+                    req.put("description", chemistryQuestion.getId());
 
                     response = getResponseFromExternalValidator(req);
 
@@ -449,7 +449,8 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
             }
         }
 
-        return new QuestionValidationResponse(symbolicQuestion.getId(), answer, responseCorrect, feedback, new Date());
+        return new QuestionValidationResponse(chemistryQuestion.getId(), answer, responseCorrect, feedback, new Date());
+    }
 
     /**
      * Create a new list of the Choice objects, sorted into correct-first order for checking.

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicChemistryValidator.java
@@ -218,16 +218,7 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
             boolean balancedKnownFlag = false;
 
             // Sort the choices so that we match incorrect choices last, taking precedence over correct ones.
-            List<Choice> orderedChoices = Lists.newArrayList(symbolicQuestion.getChoices());
-
-            Collections.sort(orderedChoices, new Comparator<Choice>() {
-                @Override
-                public int compare(final Choice o1, final Choice o2) {
-                    int o1Val = o1.isCorrect() ? 0 : 1;
-                    int o2Val = o2.isCorrect() ? 0 : 1;
-                    return o1Val - o2Val;
-                }
-            });
+            List<Choice> orderedChoices = getOrderedChoices(chemistryQuestion.getChoices());
 
             // For all the choices on this question...
             for (Choice c : orderedChoices) {
@@ -500,5 +491,23 @@ public class IsaacSymbolicChemistryValidator implements IValidator {
         }
 
         return new QuestionValidationResponse(symbolicQuestion.getId(), answer, responseCorrect, feedback, new Date());
+
+    /**
+     * Create a new list of the Choice objects, sorted into correct-first order for checking.
+     *
+     * @param choices - the Choices from a Question
+     * @return the ordered list of Choices
+     */
+    private List<Choice> getOrderedChoices(final List<Choice> choices) {
+        List<Choice> orderedChoices = Lists.newArrayList(choices);
+
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = o1.isCorrect() ? 0 : 1;
+            int o2Val = o2.isCorrect() ? 0 : 1;
+            return o1Val - o2Val;
+        });
+
+        return orderedChoices;
+    }
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
@@ -159,13 +159,7 @@ public class IsaacSymbolicValidator implements IValidator {
             MatchType closestMatchType = MatchType.NONE;
 
             // Sort the choices so that we match incorrect choices last, taking precedence over correct ones.
-            List<Choice> orderedChoices = Lists.newArrayList(symbolicQuestion.getChoices());
-
-            orderedChoices.sort((o1, o2) -> {
-                int o1Val = o1.isCorrect() ? 0 : 1;
-                int o2Val = o2.isCorrect() ? 0 : 1;
-                return o1Val - o2Val;
-            });
+            List<Choice> orderedChoices = getOrderedChoices(symbolicQuestion.getChoices());
 
             // For all the choices on this question...
             for (Choice c : orderedChoices) {
@@ -308,5 +302,23 @@ public class IsaacSymbolicValidator implements IValidator {
         // If we got this far and feedback is still null, they were wrong. There's no useful feedback we can give at this point.
 
         return new FormulaValidationResponse(symbolicQuestion.getId(), answer, feedback, responseCorrect, responseMatchType.toString(), new Date());
+    }
+
+    /**
+     * Create a new list of the Choice objects, sorted into correct-first order for checking.
+     *
+     * @param choices - the Choices from a Question
+     * @return the ordered list of Choices
+     */
+    private List<Choice> getOrderedChoices(final List<Choice> choices) {
+        List<Choice> orderedChoices = Lists.newArrayList(choices);
+
+        orderedChoices.sort((o1, o2) -> {
+            int o1Val = o1.isCorrect() ? 0 : 1;
+            int o2Val = o2.isCorrect() ? 0 : 1;
+            return o1Val - o2Val;
+        });
+
+        return orderedChoices;
     }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/IsaacSymbolicValidator.java
@@ -201,8 +201,7 @@ public class IsaacSymbolicValidator implements IValidator {
                     if (response.containsKey("error")) {
                         if (response.containsKey("code")) {
                             log.error("Failed to check formula \"" + submittedFormula.getPythonExpression()
-                                    + "\" against \"" + formulaChoice.getPythonExpression() + "\": "
-                                    + response.get("error"));
+                                    + "\" against \"" + formulaChoice.getPythonExpression() + "\": " + response.get("error"));
                         } else if (response.containsKey("syntax_error")) {
                             // There's a syntax error in the "test" expression, no use checking it further:
                             closestMatch = null;
@@ -246,7 +245,6 @@ public class IsaacSymbolicValidator implements IValidator {
                 }
             }
 
-
             if (null != closestMatch) {
                 // We found a decent match. Of course, it still might be wrong.
 
@@ -275,9 +273,6 @@ public class IsaacSymbolicValidator implements IValidator {
                             + "for question " + symbolicQuestion.getId() + ". Choice: "
                             + closestMatch.getPythonExpression() + ", submitted: "
                             + submittedFormula.getPythonExpression());
-
-                    // TODO: Decide whether we want to add something to the explanation along the lines of "you got it
-                    //       right, but only numerically.
                 }
 
             }


### PR DESCRIPTION
In writing up how the validators work, it became clear that there is a fair deal of duplicated code shared between them; but that they are also full of oddities from their initial designs. This brings them into a more consistent design and updates or removes incorrect documentation and comments.

There's still two duplicated methods that ought to be in a shared file, but I'm not sure where. Since we use Java 8, we could commit the abomination of adding methods to the `IValidator` interface itself? Or use a utility class as for [`RequestIPExtractor`](https://github.com/ucam-cl-dtg/isaac-api/blob/master/src/main/java/uk/ac/cam/cl/dtg/util/RequestIPExtractor.java) or suchlike?

I also quite like the `exactStringMatch(...)` method `IsaacNumericValidator` has, but I don't think that can be generalised because we want to compare different properties depending on what type of question it is (and it's only a separate method in numeric validation because the flow is so complicated already).

---

**Pull Request Check List**
- [x] Removed Unnecessary Logs/System.Outs/Comments/TODOs
